### PR TITLE
Feature/8 edit event screen improve UI

### DIFF
--- a/lib/screens/drawer_screen.dart
+++ b/lib/screens/drawer_screen.dart
@@ -38,13 +38,16 @@ class DrawerScreen extends StatelessWidget {
                       );
                     },
                   ),
-                  Flexible(
+                  Expanded(
                     child: ListView.builder(
-                      physics: const ScrollPhysics(),
+                      physics: ScrollPhysics(),
                       itemCount: model.groupName.length,
                       itemBuilder: (BuildContext context, int index) {
                         return ListTile(
-                          title: Text(model.groupName[index]),
+                          title: Text(
+                            model.groupName[index],
+                            overflow: TextOverflow.ellipsis,
+                          ),
                           onTap: () {
                             Navigator.push(
                               context,

--- a/lib/screens/group_screens/group_edit_event_screen.dart
+++ b/lib/screens/group_screens/group_edit_event_screen.dart
@@ -52,65 +52,64 @@ class GroupEditEventScreen extends StatelessWidget {
               ),
               body: Padding(
                 padding: EdgeInsets.only(top: 8.0, left: 16.0, right: 16.0),
-                child: Column(
-                  children: <Widget>[
-                    TextField(
-                      controller: eventTitleController,
-                      decoration: InputDecoration(hintText: 'タイトル'),
-                      onChanged: (text) {
-                        model.eventTitle = text;
-                      },
-                    ),
-                    TextField(
-                      controller: eventPlaceController,
-                      decoration: InputDecoration(hintText: '場所'),
-                      onChanged: (text) {
-                        model.eventPlace = text;
-                      },
-                    ),
-                    SizedBox(
-                      height: 30.0,
-                    ),
-                    SwitchListTile(
-                      value: model.isAllDay,
-                      title: Text('終日'),
-                      onChanged: (value) {
-                        model.switchIsAllDay(value);
-                      },
-                    ),
-                    Divider(height: 0.5),
-                    ListTile(
-                      title: Text('開始'),
-                      trailing: Text(
-                          model.tileDateFormat.format(model.startingDateTime)),
-                      onTap: () {
-                        model.showStartingDateTimePicker();
-                      },
-                    ),
-                    model.startingDateTimePickerBox,
-                    Divider(height: 0.5),
-                    ListTile(
-                      title: Text('終了'),
-                      trailing: Text(
-                          model.tileDateFormat.format(model.endingDateTime)),
-                      onTap: () {
-                        model.showEndingDateTimePicker();
-                      },
-                    ),
-                    model.endingDateTimePickerBox,
-                    TextField(
-                      controller: eventMemoController,
-                      maxLines: 10,
-                      maxLength: 200,
-                      decoration: InputDecoration(hintText: 'メモ'),
-                      onChanged: (text) {
-                        model.eventMemo = text;
-                      },
-                    ),
-                    Expanded(
-                      child: SizedBox(),
-                    ),
-                  ],
+                child: SingleChildScrollView(
+                  child: Column(
+                    children: <Widget>[
+                      TextField(
+                        controller: eventTitleController,
+                        decoration: InputDecoration(hintText: 'タイトル'),
+                        onChanged: (text) {
+                          model.eventTitle = text;
+                        },
+                      ),
+                      TextField(
+                        controller: eventPlaceController,
+                        decoration: InputDecoration(hintText: '場所'),
+                        onChanged: (text) {
+                          model.eventPlace = text;
+                        },
+                      ),
+                      SizedBox(
+                        height: 30.0,
+                      ),
+                      SwitchListTile(
+                        value: model.isAllDay,
+                        title: Text('終日'),
+                        onChanged: (value) {
+                          model.switchIsAllDay(value);
+                        },
+                      ),
+                      Divider(height: 0.5),
+                      ListTile(
+                        title: Text('開始'),
+                        trailing: Text(model.tileDateFormat
+                            .format(model.startingDateTime)),
+                        onTap: () {
+                          model.showStartingDateTimePicker();
+                        },
+                      ),
+                      model.startingDateTimePickerBox,
+                      Divider(height: 0.5),
+                      ListTile(
+                        title: Text('終了'),
+                        trailing: Text(
+                            model.tileDateFormat.format(model.endingDateTime)),
+                        onTap: () {
+                          model.showEndingDateTimePicker();
+                        },
+                      ),
+                      model.endingDateTimePickerBox,
+                      TextField(
+                        controller: eventMemoController,
+                        maxLines: 10,
+                        maxLength: 200,
+                        decoration: InputDecoration(hintText: 'メモ'),
+                        onChanged: (text) {
+                          model.eventMemo = text;
+                        },
+                      ),
+                    ],
+                  ),
                 ),
               ),
             ),

--- a/lib/screens/group_screens/group_screen.dart
+++ b/lib/screens/group_screens/group_screen.dart
@@ -26,7 +26,10 @@ class GroupScreen extends StatelessWidget {
           return Scaffold(
             drawer: DrawerScreen(),
             appBar: AppBar(
-              title: Text(model.groupName),
+              title: Text(
+                model.groupName,
+                textAlign: TextAlign.center,
+              ),
               actions: <Widget>[
                 IconButton(
                   icon: Icon(Icons.settings),

--- a/lib/screens/group_setting_screens/group_member_screen.dart
+++ b/lib/screens/group_setting_screens/group_member_screen.dart
@@ -43,7 +43,10 @@ class GroupMemberScreen extends StatelessWidget {
                                     : AssetImage('images/test_user_image.png'),
                                 backgroundColor: Colors.transparent,
                               ),
-                              title: Text(userName),
+                              title: Text(
+                                userName,
+                                overflow: TextOverflow.ellipsis,
+                              ),
                               onTap: () async {
                                 bool isMe = userID == model.myID;
                                 bool isDelete = await _showMemberBottomSheet(

--- a/lib/screens/group_setting_screens/group_setting_screen.dart
+++ b/lib/screens/group_setting_screens/group_setting_screen.dart
@@ -50,11 +50,16 @@ class GroupSettingScreen extends StatelessWidget {
                         ),
                       ),
                       SizedBox(height: 4.0),
-                      Text(
-                        model.groupName != null
-                            ? model.groupName
-                            : 'Loading...',
-                        style: TextStyle(fontWeight: FontWeight.bold),
+                      Padding(
+                        padding: EdgeInsets.symmetric(horizontal: 16.0),
+                        child: Text(
+                          model.groupName != null
+                              ? model.groupName
+                              : 'Loading...',
+                          style: TextStyle(fontWeight: FontWeight.bold),
+                          textAlign: TextAlign.center,
+                          overflow: TextOverflow.ellipsis,
+                        ),
                       ),
                     ],
                   ),

--- a/lib/screens/user_screens/user_edit_event_screen.dart
+++ b/lib/screens/user_screens/user_edit_event_screen.dart
@@ -52,65 +52,64 @@ class UserEditEventScreen extends StatelessWidget {
               ),
               body: Padding(
                 padding: EdgeInsets.only(top: 8.0, left: 16.0, right: 16.0),
-                child: Column(
-                  children: <Widget>[
-                    TextField(
-                      controller: eventTitleController,
-                      decoration: InputDecoration(hintText: 'タイトル'),
-                      onChanged: (text) {
-                        model.eventTitle = text;
-                      },
-                    ),
-                    TextField(
-                      controller: eventPlaceController,
-                      decoration: InputDecoration(hintText: '場所'),
-                      onChanged: (text) {
-                        model.eventPlace = text;
-                      },
-                    ),
-                    SizedBox(
-                      height: 30.0,
-                    ),
-                    SwitchListTile(
-                      value: model.isAllDay,
-                      title: Text('終日'),
-                      onChanged: (value) {
-                        model.switchIsAllDay(value);
-                      },
-                    ),
-                    Divider(height: 0.5),
-                    ListTile(
-                      title: Text('開始'),
-                      trailing: Text(
-                          model.tileDateFormat.format(model.startingDateTime)),
-                      onTap: () {
-                        model.showStartingDateTimePicker();
-                      },
-                    ),
-                    model.startingDateTimePickerBox,
-                    Divider(height: 0.5),
-                    ListTile(
-                      title: Text('終了'),
-                      trailing: Text(
-                          model.tileDateFormat.format(model.endingDateTime)),
-                      onTap: () {
-                        model.showEndingDateTimePicker();
-                      },
-                    ),
-                    model.endingDateTimePickerBox,
-                    TextField(
-                      controller: eventMemoController,
-                      maxLines: 10,
-                      maxLength: 200,
-                      decoration: InputDecoration(hintText: 'メモ'),
-                      onChanged: (text) {
-                        model.eventMemo = text;
-                      },
-                    ),
-                    Expanded(
-                      child: SizedBox(),
-                    ),
-                  ],
+                child: SingleChildScrollView(
+                  child: Column(
+                    children: <Widget>[
+                      TextField(
+                        controller: eventTitleController,
+                        decoration: InputDecoration(hintText: 'タイトル'),
+                        onChanged: (text) {
+                          model.eventTitle = text;
+                        },
+                      ),
+                      TextField(
+                        controller: eventPlaceController,
+                        decoration: InputDecoration(hintText: '場所'),
+                        onChanged: (text) {
+                          model.eventPlace = text;
+                        },
+                      ),
+                      SizedBox(
+                        height: 30.0,
+                      ),
+                      SwitchListTile(
+                        value: model.isAllDay,
+                        title: Text('終日'),
+                        onChanged: (value) {
+                          model.switchIsAllDay(value);
+                        },
+                      ),
+                      Divider(height: 0.5),
+                      ListTile(
+                        title: Text('開始'),
+                        trailing: Text(model.tileDateFormat
+                            .format(model.startingDateTime)),
+                        onTap: () {
+                          model.showStartingDateTimePicker();
+                        },
+                      ),
+                      model.startingDateTimePickerBox,
+                      Divider(height: 0.5),
+                      ListTile(
+                        title: Text('終了'),
+                        trailing: Text(
+                            model.tileDateFormat.format(model.endingDateTime)),
+                        onTap: () {
+                          model.showEndingDateTimePicker();
+                        },
+                      ),
+                      model.endingDateTimePickerBox,
+                      TextField(
+                        controller: eventMemoController,
+                        maxLines: 10,
+                        maxLength: 200,
+                        decoration: InputDecoration(hintText: 'メモ'),
+                        onChanged: (text) {
+                          model.eventMemo = text;
+                        },
+                      ),
+                    ],
+                  ),
                 ),
               ),
             ),

--- a/lib/screens/user_screens/user_screen.dart
+++ b/lib/screens/user_screens/user_screen.dart
@@ -23,7 +23,10 @@ class UserScreen extends StatelessWidget {
           return Scaffold(
             drawer: DrawerScreen(),
             appBar: AppBar(
-              title: Text(model.userName),
+              title: Text(
+                model.userName,
+                textAlign: TextAlign.center,
+              ),
               actions: <Widget>[
                 IconButton(
                   icon: Icon(

--- a/lib/screens/user_setting_screens/user_setting_screen.dart
+++ b/lib/screens/user_setting_screens/user_setting_screen.dart
@@ -50,9 +50,16 @@ class UserSettingScreen extends StatelessWidget {
                         ),
                       ),
                       SizedBox(height: 4.0),
-                      Text(
-                        model.userName != null ? model.userName : 'Loading...',
-                        style: TextStyle(fontWeight: FontWeight.bold),
+                      Padding(
+                        padding: EdgeInsets.symmetric(horizontal: 16.0),
+                        child: Text(
+                          model.userName != null
+                              ? model.userName
+                              : 'Loading...',
+                          style: TextStyle(fontWeight: FontWeight.bold),
+                          textAlign: TextAlign.center,
+                          overflow: TextOverflow.ellipsis,
+                        ),
                       ),
                     ],
                   ),

--- a/lib/widgets/event_list_tile.dart
+++ b/lib/widgets/event_list_tile.dart
@@ -92,9 +92,12 @@ class EventPlannerImage extends StatelessWidget {
             ),
           ),
           SizedBox(width: 5.0),
-          Text(
-            name,
-            style: TextStyle(fontWeight: FontWeight.bold),
+          Expanded(
+            child: Text(
+              name,
+              style: TextStyle(fontWeight: FontWeight.bold),
+              overflow: TextOverflow.ellipsis,
+            ),
           ),
         ],
       );
@@ -116,27 +119,34 @@ class EventOverViewWidget extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     if (eventPlace.isNotEmpty) {
-      return Column(
-        mainAxisAlignment: MainAxisAlignment.spaceEvenly,
-        crossAxisAlignment: CrossAxisAlignment.start,
-        children: <Widget>[
-          Text(
-            eventTitle,
-            style: TextStyle(fontSize: 16.0),
-          ),
-          Text(
-            '@ $eventPlace',
-            style: TextStyle(
-              color: Colors.black54,
-              fontSize: 14.0,
+      return Expanded(
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.spaceEvenly,
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: <Widget>[
+            Text(
+              eventTitle,
+              style: TextStyle(fontSize: 16.0),
+              overflow: TextOverflow.ellipsis,
             ),
-          ),
-        ],
+            Text(
+              '@ $eventPlace',
+              style: TextStyle(
+                color: Colors.black54,
+                fontSize: 14.0,
+              ),
+              overflow: TextOverflow.ellipsis,
+            ),
+          ],
+        ),
       );
     } else
-      return Text(
-        eventTitle,
-        style: TextStyle(fontSize: 16.0),
+      return Expanded(
+        child: Text(
+          eventTitle,
+          style: TextStyle(fontSize: 16.0),
+          overflow: TextOverflow.ellipsis,
+        ),
       );
   }
 }

--- a/lib/widgets/song_list_tile.dart
+++ b/lib/widgets/song_list_tile.dart
@@ -21,7 +21,7 @@ class SongListTile extends StatelessWidget {
     return ListTile(
       title: Text(
         songTitle,
-        maxLines: 1,
+        overflow: TextOverflow.ellipsis,
       ),
       subtitle: Visibility(
         visible: isVisible,


### PR DESCRIPTION
## 関連するissue
#8
## 変更点
- イベント編集画面でUIが崩れていたバグを修正した
- 各画面で表示される名前などのテキストが長すぎるとUIが崩れるので、表示の仕方をTextOverflow.ellipsisで揃えた