### PR TITLE
Feature/9 limit how many groups join

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -38,7 +38,7 @@ service cloud.firestore {
     // イベントデータのスキーマ検証
     function isValidEventData(eventData) {
       return eventData.size() == 11
-        && 'ownerID' in eventData && eventData.ownerID is string
+        && 'ownerId' in eventData && eventData.ownerId is string
         && 'title' in eventData && eventData.title is string
         && 'place' in eventData && eventData.place is string
         && 'memo' in eventData && eventData.memo is string
@@ -54,13 +54,13 @@ service cloud.firestore {
     // タスクデータのスキーマ検証
     function isValidTaskData(taskData) {
       return taskData.size() == 9
-        && 'ownerID' in taskData && taskData.ownerID is string
+        && 'ownerId' in taskData && taskData.ownerId is string
         && 'title' in taskData && taskData.title is string
         && 'memo' in taskData && taskData.memo is string
         && 'isCompleted' in taskData && taskData.isCompleted is bool
         && 'isDecidedDueDate' in taskData && taskData.isDecidedDueDate is bool
         && 'dueDate' in taskData && (taskData.dueDate is timestamp || taskData.dueDate == null)
-        && 'assignedMembersID' in taskData && taskData.assignedMembersID is list
+        && 'assignedMembersId' in taskData && taskData.assignedMembersId is list
         && 'createdAt' in taskData && taskData.createdAt is timestamp
         && 'updatedAt' in taskData && taskData.updatedAt is timestamp;
     }
@@ -114,7 +114,7 @@ service cloud.firestore {
 
         allow create: if isDocumentAuthor(userId)
           && isValidEventData(request.resource.data)
-          && request.resource.data.ownerID == userId
+          && request.resource.data.ownerId == userId
           && request.resource.data.title.size() >= 1
           && request.resource.data.monthList.size() >= 1
           && request.resource.data.dateList.size() >= 1
@@ -123,7 +123,7 @@ service cloud.firestore {
 
         allow update: if isDocumentAuthor(userId)
           && isValidEventData(request.resource.data)
-          && request.resource.data.ownerID == resource.data.ownerID
+          && request.resource.data.ownerId == resource.data.ownerId
           && request.resource.data.title.size() >= 1
           && request.resource.data.monthList.size() >= 1
           && request.resource.data.dateList.size() >= 1
@@ -139,19 +139,19 @@ service cloud.firestore {
 
         allow create: if isDocumentAuthor(userId)
           && isValidTaskData(request.resource.data)
-          && request.resource.data.ownerID == userId
+          && request.resource.data.ownerId == userId
           && request.resource.data.title.size() >= 1
-          && request.resource.data.assignedMembersID.size() == 1
-          && request.resource.data.assignedMembersID.hasOnly([userId])
+          && request.resource.data.assignedMembersId.size() == 1
+          && request.resource.data.assignedMembersId.hasOnly([userId])
           && request.resource.data.isCompleted == false
           && request.resource.data.createdAt == request.time
           && request.resource.data.updatedAt == request.time;
 
         allow update: if isDocumentAuthor(userId)
           && isValidTaskData(request.resource.data)
-          && request.resource.data.ownerID == resource.data.ownerID
+          && request.resource.data.ownerId == resource.data.ownerId
           && request.resource.data.title.size() >= 1
-          && request.resource.data.assignedMembersID == resource.data.assignedMembersID
+          && request.resource.data.assignedMembersId == resource.data.assignedMembersId
           && request.resource.data.createdAt == resource.data.createdAt
           && request.resource.data.updatedAt == request.time;
 
@@ -200,7 +200,7 @@ service cloud.firestore {
 
         allow create: if isGroupMember(request.auth.uid, groupId)
           && isValidEventData(request.resource.data)
-          && request.resource.data.ownerID == groupId
+          && request.resource.data.ownerId == groupId
           && request.resource.data.title.size() >= 1
           && request.resource.data.monthList.size() >= 1
           && request.resource.data.dateList.size() >= 1
@@ -209,7 +209,7 @@ service cloud.firestore {
 
         allow update: if isGroupMember(request.auth.uid, groupId)
           && isValidEventData(request.resource.data)
-          && request.resource.data.ownerID == resource.data.ownerID
+          && request.resource.data.ownerId == resource.data.ownerId
           && request.resource.data.title.size() >= 1
           && request.resource.data.monthList.size() >= 1
           && request.resource.data.dateList.size() >= 1
@@ -225,7 +225,7 @@ service cloud.firestore {
 
         allow create: if isGroupMember(request.auth.uid, groupId)
           && isValidTaskData(request.resource.data)
-          && request.resource.data.ownerID == groupId
+          && request.resource.data.ownerId == groupId
           && request.resource.data.title.size() >= 1
           && request.resource.data.isCompleted == false
           && request.resource.data.createdAt == request.time
@@ -233,7 +233,7 @@ service cloud.firestore {
 
         allow update: if isGroupMember(request.auth.uid, groupId)
           && isValidTaskData(request.resource.data)
-          && request.resource.data.ownerID == resource.data.ownerID
+          && request.resource.data.ownerId == resource.data.ownerId
           && request.resource.data.title.size() >= 1
           && request.resource.data.createdAt == resource.data.createdAt
           && request.resource.data.updatedAt == request.time;

--- a/lib/models/add_group_model.dart
+++ b/lib/models/add_group_model.dart
@@ -6,14 +6,9 @@ class AddGroupModel extends ChangeNotifier {
   String userName = '';
   String userImageURL = '';
   String groupName = '';
-  String groupID;
+  String groupId;
   bool isLoading = false;
   final _auth = Auth.FirebaseAuth.instance;
-
-  void init({String userName, String userImageURL}) {
-    this.userName = userName;
-    this.userImageURL = userImageURL;
-  }
 
   void startLoading() {
     isLoading = true;
@@ -23,6 +18,11 @@ class AddGroupModel extends ChangeNotifier {
   void endLoading() {
     isLoading = false;
     notifyListeners();
+  }
+
+  void init({String userName, String userImageURL}) {
+    this.userName = userName;
+    this.userImageURL = userImageURL;
   }
 
   Future addGroup() async {
@@ -37,10 +37,10 @@ class AddGroupModel extends ChangeNotifier {
         'imageURL': '',
         'createdAt': FieldValue.serverTimestamp(),
       });
-      groupID = newGroup.id;
+      groupId = newGroup.id;
       await FirebaseFirestore.instance
           .collection('groups')
-          .doc(groupID)
+          .doc(groupId)
           .collection('groupUsers')
           .doc(user.uid)
           .set({
@@ -52,7 +52,7 @@ class AddGroupModel extends ChangeNotifier {
           .collection('users')
           .doc(user.uid)
           .collection('joiningGroup')
-          .doc(groupID)
+          .doc(groupId)
           .set({
         'name': groupName,
         'imageURL': '',

--- a/lib/models/drawer_model.dart
+++ b/lib/models/drawer_model.dart
@@ -10,6 +10,7 @@ class DrawerModel extends ChangeNotifier {
   List<String> groupsName = [];
   List<String> groupsId = [];
   bool isLoading = false;
+  final firestore = FirebaseFirestore.instance;
 
   void startLoading() {
     isLoading = true;
@@ -25,12 +26,10 @@ class DrawerModel extends ChangeNotifier {
     startLoading();
     userId = auth.currentUser.uid;
     try {
-      DocumentSnapshot userDoc = await FirebaseFirestore.instance
-          .collection('users')
-          .doc(userId)
-          .get();
+      DocumentSnapshot userDoc =
+          await firestore.collection('users').doc(userId).get();
 
-      QuerySnapshot joiningGroup = await FirebaseFirestore.instance
+      QuerySnapshot joiningGroup = await firestore
           .collection('users')
           .doc(userId)
           .collection('joiningGroup')

--- a/lib/models/drawer_model.dart
+++ b/lib/models/drawer_model.dart
@@ -4,11 +4,11 @@ import 'package:cloud_firestore/cloud_firestore.dart';
 
 class DrawerModel extends ChangeNotifier {
   final _auth = Auth.FirebaseAuth.instance;
-  String userID;
+  String userId;
   String userImageURL = '';
   String userName = '';
-  List<String> groupName = [];
-  List<String> groupID = [];
+  List<String> groupsName = [];
+  List<String> groupsId = [];
   bool isLoading = false;
 
   void startLoading() {
@@ -23,23 +23,23 @@ class DrawerModel extends ChangeNotifier {
 
   Future init() async {
     startLoading();
-    userID = _auth.currentUser.uid;
+    userId = _auth.currentUser.uid;
     try {
       DocumentSnapshot userDoc = await FirebaseFirestore.instance
           .collection('users')
-          .doc(userID)
+          .doc(userId)
           .get();
 
       QuerySnapshot joiningGroup = await FirebaseFirestore.instance
           .collection('users')
-          .doc(userID)
+          .doc(userId)
           .collection('joiningGroup')
           .get();
 
       userImageURL = userDoc['imageURL'];
       userName = userDoc['name'];
-      groupID = (joiningGroup.docs.map((doc) => doc.id).toList());
-      groupName =
+      groupsId = (joiningGroup.docs.map((doc) => doc.id).toList());
+      groupsName =
           (joiningGroup.docs.map((doc) => doc['name'].toString()).toList());
     } catch (e) {
       print(e);

--- a/lib/models/drawer_model.dart
+++ b/lib/models/drawer_model.dart
@@ -3,7 +3,7 @@ import 'package:flutter/material.dart';
 import 'package:cloud_firestore/cloud_firestore.dart';
 
 class DrawerModel extends ChangeNotifier {
-  final _auth = Auth.FirebaseAuth.instance;
+  final auth = Auth.FirebaseAuth.instance;
   String userId;
   String userImageURL = '';
   String userName = '';
@@ -23,7 +23,7 @@ class DrawerModel extends ChangeNotifier {
 
   Future init() async {
     startLoading();
-    userId = _auth.currentUser.uid;
+    userId = auth.currentUser.uid;
     try {
       DocumentSnapshot userDoc = await FirebaseFirestore.instance
           .collection('users')

--- a/lib/models/group_models/group_add_event_model.dart
+++ b/lib/models/group_models/group_add_event_model.dart
@@ -134,7 +134,7 @@ class GroupAddEventModel extends ChangeNotifier {
     notifyListeners();
   }
 
-  Future addEvent({groupID}) async {
+  Future addEvent({groupId}) async {
     if (eventTitle.isEmpty) {
       throw ('タイトルを入力してください');
     }
@@ -183,10 +183,10 @@ class GroupAddEventModel extends ChangeNotifier {
     try {
       await FirebaseFirestore.instance
           .collection('groups')
-          .doc(groupID)
+          .doc(groupId)
           .collection('events')
           .add({
-        'ownerID': groupID,
+        'ownerId': groupId,
         'title': eventTitle,
         'place': eventPlace,
         'memo': eventMemo,

--- a/lib/models/group_models/group_add_song_model.dart
+++ b/lib/models/group_models/group_add_song_model.dart
@@ -18,14 +18,14 @@ class GroupAddSongModel extends ChangeNotifier {
     notifyListeners();
   }
 
-  Future addSong(groupID) async {
+  Future addSong({String groupId}) async {
     if (songTitle.isEmpty) {
       throw ('タイトルを入力してください');
     }
     try {
       await FirebaseFirestore.instance
           .collection('groups')
-          .doc(groupID)
+          .doc(groupId)
           .collection('songs')
           .add({
         'title': songTitle,

--- a/lib/models/group_models/group_add_task_model.dart
+++ b/lib/models/group_models/group_add_task_model.dart
@@ -5,13 +5,13 @@ import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:intl/intl.dart';
 
 class GroupAddTaskModel extends ChangeNotifier {
-  String groupID = '';
+  String groupId = '';
   String taskTitle = '';
   String taskMemo = '';
   String dueDateText = '';
   bool isDecidedDueDate = true;
-  List<String> assignedMembersID = [];
-  List<String> userIDs = [];
+  List<String> assignedMembersId = [];
+  List<String> usersId = [];
   List<String> userNames = [];
   List<String> userImageURLs = [];
   bool isLoading = false;
@@ -31,18 +31,18 @@ class GroupAddTaskModel extends ChangeNotifier {
     notifyListeners();
   }
 
-  void init({String groupID}) async {
+  void init({String groupId}) async {
     startLoading();
-    this.groupID = groupID;
+    this.groupId = groupId;
     this.dueDate = DateTime(now.year, now.month, now.day, 12);
     this.dueDateText = dateFormat.format(dueDate);
     try {
       QuerySnapshot groupUsers = await FirebaseFirestore.instance
           .collection('groups')
-          .doc(groupID)
+          .doc(groupId)
           .collection('groupUsers')
           .get();
-      userIDs = (groupUsers.docs.map((doc) => doc.id).toList());
+      usersId = (groupUsers.docs.map((doc) => doc.id).toList());
       userNames =
           (groupUsers.docs.map((doc) => doc['name'].toString()).toList());
       userImageURLs =
@@ -54,11 +54,11 @@ class GroupAddTaskModel extends ChangeNotifier {
     }
   }
 
-  void assignPerson(userID) {
-    if (assignedMembersID.contains(userID)) {
-      assignedMembersID.remove(userID);
+  void assignPerson(userId) {
+    if (assignedMembersId.contains(userId)) {
+      assignedMembersId.remove(userId);
     } else {
-      assignedMembersID.add(userID);
+      assignedMembersId.add(userId);
     }
     notifyListeners();
   }
@@ -117,15 +117,15 @@ class GroupAddTaskModel extends ChangeNotifier {
     try {
       await FirebaseFirestore.instance
           .collection('groups')
-          .doc(groupID)
+          .doc(groupId)
           .collection('tasks')
           .add({
         'title': taskTitle,
         'memo': taskMemo,
         'isDecidedDueDate': isDecidedDueDate,
         'dueDate': isDecidedDueDate ? Timestamp.fromDate(dueDate) : null,
-        'assignedMembersID': assignedMembersID,
-        'ownerID': groupID,
+        'assignedMembersId': assignedMembersId,
+        'ownerId': groupId,
         'isCompleted': false,
         'createdAt': FieldValue.serverTimestamp(),
         'updatedAt': FieldValue.serverTimestamp(),

--- a/lib/models/group_models/group_calendar_model.dart
+++ b/lib/models/group_models/group_calendar_model.dart
@@ -5,7 +5,7 @@ import 'package:intl/intl.dart';
 import 'package:nholiday_jp/nholiday_jp.dart';
 
 class GroupCalendarModel extends ChangeNotifier {
-  String groupID = '';
+  String groupId = '';
   DateTime now = DateTime.now();
   DateTime first;
   DateTime last;
@@ -16,8 +16,8 @@ class GroupCalendarModel extends ChangeNotifier {
   final DateFormat dateFormat = DateFormat('y-MM-dd');
   final DateFormat monthFormat = DateFormat('y-MM');
 
-  void init({String groupID}) {
-    this.groupID = groupID;
+  void init({String groupId}) {
+    this.groupId = groupId;
     this.selectedDay = DateTime(now.year, now.month, now.day, 12);
   }
 
@@ -32,7 +32,7 @@ class GroupCalendarModel extends ChangeNotifier {
     try {
       QuerySnapshot eventDoc = await FirebaseFirestore.instance
           .collection('groups')
-          .doc(groupID)
+          .doc(groupId)
           .collection('events')
           .where('monthList', arrayContains: monthForm)
           .get();

--- a/lib/models/group_models/group_edit_event_model.dart
+++ b/lib/models/group_models/group_edit_event_model.dart
@@ -4,8 +4,8 @@ import 'package:flutter/material.dart';
 import 'package:intl/intl.dart';
 
 class GroupEditEventModel extends ChangeNotifier {
-  String ownerID;
-  String eventID;
+  String ownerId;
+  String eventId;
   String eventTitle = '';
   String eventPlace = '';
   String eventMemo = '';
@@ -60,8 +60,8 @@ class GroupEditEventModel extends ChangeNotifier {
         );
       }
     }
-    ownerID = event.ownerID;
-    eventID = event.id;
+    ownerId = event.ownerId;
+    eventId = event.id;
     eventTitle = event.title;
     eventPlace = event.place;
     eventMemo = event.memo;
@@ -168,7 +168,7 @@ class GroupEditEventModel extends ChangeNotifier {
     notifyListeners();
   }
 
-  Future updateEvent({groupID}) async {
+  Future updateEvent({groupId}) async {
     if (eventTitle.isEmpty) {
       throw ('タイトルを入力してください');
     }
@@ -217,9 +217,9 @@ class GroupEditEventModel extends ChangeNotifier {
     try {
       await FirebaseFirestore.instance
           .collection('groups')
-          .doc(groupID)
+          .doc(groupId)
           .collection('events')
-          .doc(eventID)
+          .doc(eventId)
           .update({
         'title': eventTitle,
         'place': eventPlace,

--- a/lib/models/group_models/group_edit_song_model.dart
+++ b/lib/models/group_models/group_edit_song_model.dart
@@ -3,17 +3,17 @@ import 'package:flutter/material.dart';
 import 'package:cloud_firestore/cloud_firestore.dart';
 
 class GroupEditSongModel extends ChangeNotifier {
-  String groupID = '';
-  String songID = '';
+  String groupId = '';
+  String songId = '';
   String songTitle = '';
   String songMemo = '';
   int songPlayingTime;
   bool isLoading = false;
   final List<int> songPlayingTimes = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12];
 
-  void init({String groupID, Song song}) {
-    this.groupID = groupID;
-    this.songID = song.id;
+  void init({String groupId, Song song}) {
+    this.groupId = groupId;
+    this.songId = song.id;
     this.songTitle = song.title;
     this.songMemo = song.memo;
     this.songPlayingTime = song.playingTime;
@@ -36,9 +36,9 @@ class GroupEditSongModel extends ChangeNotifier {
     try {
       await FirebaseFirestore.instance
           .collection('groups')
-          .doc(groupID)
+          .doc(groupId)
           .collection('songs')
-          .doc(songID)
+          .doc(songId)
           .update({
         'title': songTitle,
         'memo': songMemo,

--- a/lib/models/group_models/group_edit_task_model.dart
+++ b/lib/models/group_models/group_edit_task_model.dart
@@ -6,15 +6,15 @@ import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:intl/intl.dart';
 
 class GroupEditTaskModel extends ChangeNotifier {
-  String groupID = '';
-  String taskID = '';
+  String groupId = '';
+  String taskId = '';
   String taskTitle = '';
   String taskMemo = '';
   String dueDateText = '';
   bool isDecidedDueDate;
   bool isCompleted;
-  List<String> assignedMembersID = [];
-  List<String> userIDs = [];
+  List<String> assignedMembersId = [];
+  List<String> usersId = [];
   List<String> userNames = [];
   List<String> userImageURLs = [];
   bool isLoading = false;
@@ -33,25 +33,25 @@ class GroupEditTaskModel extends ChangeNotifier {
     notifyListeners();
   }
 
-  void init({String groupID, Task task}) async {
+  void init({String groupId, Task task}) async {
     startLoading();
-    this.groupID = groupID;
-    this.taskID = task.id;
+    this.groupId = groupId;
+    this.taskId = task.id;
     this.taskTitle = task.title;
     this.taskMemo = task.memo;
     this.isDecidedDueDate = task.isDecidedDueDate;
     this.isCompleted = task.isCompleted;
     this.dueDate = task.dueDate;
     this.dueDateText = task.isDecidedDueDate ? dateFormat.format(dueDate) : '';
-    this.assignedMembersID =
-        task.assignedMembersID.map((id) => id.toString()).toList();
+    this.assignedMembersId =
+        task.assignedMembersId.map((id) => id.toString()).toList();
     try {
       QuerySnapshot groupUsers = await FirebaseFirestore.instance
           .collection('groups')
-          .doc(groupID)
+          .doc(groupId)
           .collection('groupUsers')
           .get();
-      userIDs = (groupUsers.docs.map((doc) => doc.id).toList());
+      usersId = (groupUsers.docs.map((doc) => doc.id).toList());
       userNames =
           (groupUsers.docs.map((doc) => doc['name'].toString()).toList());
       userImageURLs =
@@ -63,11 +63,11 @@ class GroupEditTaskModel extends ChangeNotifier {
     }
   }
 
-  void assignPerson(userID) {
-    if (assignedMembersID.contains(userID)) {
-      assignedMembersID.remove(userID);
+  void assignPerson(userId) {
+    if (assignedMembersId.contains(userId)) {
+      assignedMembersId.remove(userId);
     } else {
-      assignedMembersID.add(userID);
+      assignedMembersId.add(userId);
     }
     notifyListeners();
   }
@@ -126,15 +126,15 @@ class GroupEditTaskModel extends ChangeNotifier {
     try {
       await FirebaseFirestore.instance
           .collection('groups')
-          .doc(groupID)
+          .doc(groupId)
           .collection('tasks')
-          .doc(taskID)
+          .doc(taskId)
           .update({
         'title': taskTitle,
         'memo': taskMemo,
         'isDecidedDueDate': isDecidedDueDate,
         'dueDate': isDecidedDueDate ? Timestamp.fromDate(dueDate) : null,
-        'assignedMembersID': assignedMembersID,
+        'assignedMembersId': assignedMembersId,
         'updatedAt': FieldValue.serverTimestamp(),
       });
     } catch (e) {

--- a/lib/models/group_models/group_event_details_model.dart
+++ b/lib/models/group_models/group_event_details_model.dart
@@ -5,7 +5,7 @@ import 'package:flutter/material.dart';
 
 class GroupEventDetailsModel extends ChangeNotifier {
   Event event;
-  String eventID;
+  String eventId;
   String eventTitle = '';
   String eventPlace = '';
   String eventMemo = '';
@@ -26,7 +26,7 @@ class GroupEventDetailsModel extends ChangeNotifier {
 
   void init(Event event) {
     this.event = event;
-    eventID = event.id;
+    eventId = event.id;
     eventTitle = event.title;
     eventPlace = event.place;
     eventMemo = event.memo;
@@ -35,16 +35,16 @@ class GroupEventDetailsModel extends ChangeNotifier {
     endingDateTime = event.endingDateTime;
   }
 
-  Future getEvent({String groupID}) async {
+  Future getEvent({String groupId}) async {
     try {
       DocumentSnapshot eventDoc = await FirebaseFirestore.instance
           .collection('groups')
-          .doc(groupID)
+          .doc(groupId)
           .collection('events')
-          .doc(eventID)
+          .doc(eventId)
           .get();
       event = Event.doc(eventDoc);
-      eventID = event.id;
+      eventId = event.id;
       eventTitle = event.title;
       eventPlace = event.place;
       eventMemo = event.memo;
@@ -58,13 +58,13 @@ class GroupEventDetailsModel extends ChangeNotifier {
     notifyListeners();
   }
 
-  Future deleteEvent({String groupID}) async {
+  Future deleteEvent({String groupId}) async {
     try {
       await FirebaseFirestore.instance
           .collection('groups')
-          .doc(groupID)
+          .doc(groupId)
           .collection('events')
-          .doc(eventID)
+          .doc(eventId)
           .delete();
     } catch (e) {
       print(e);

--- a/lib/models/group_models/group_main_model.dart
+++ b/lib/models/group_models/group_main_model.dart
@@ -20,13 +20,13 @@ class GroupMainModel extends ChangeNotifier {
     notifyListeners();
   }
 
-  Future init({String groupID}) async {
+  Future init({String groupId}) async {
     taskCount = 0;
     startLoading();
     try {
       final taskQuery = await firestore
           .collection('groups')
-          .doc(groupID)
+          .doc(groupId)
           .collection('tasks')
           .get();
       final tasks = taskQuery.docs.map((doc) => Task.doc(doc)).toList();
@@ -35,19 +35,19 @@ class GroupMainModel extends ChangeNotifier {
           taskCount += 1;
         }
       });
-      await getEventList(groupID: groupID);
+      await getEventList(groupId: groupId);
     } catch (e) {
       print(e);
     }
     endLoading();
   }
 
-  Future getEventList({String groupID}) async {
+  Future getEventList({String groupId}) async {
     final currentTimestamp = Timestamp.fromDate(currentDateTime);
     try {
       QuerySnapshot eventDoc = await FirebaseFirestore.instance
           .collection('groups')
-          .doc(groupID)
+          .doc(groupId)
           .collection('events')
           .where('end', isGreaterThan: currentTimestamp)
           .get();

--- a/lib/models/group_models/group_model.dart
+++ b/lib/models/group_models/group_model.dart
@@ -5,10 +5,10 @@ class GroupModel extends ChangeNotifier {
   String groupName = '';
   int currentIndex = 0;
 
-  Future init({String groupID}) async {
+  Future init({String groupId}) async {
     DocumentSnapshot groupDoc = await FirebaseFirestore.instance
         .collection('groups')
-        .doc(groupID)
+        .doc(groupId)
         .get();
     groupName = groupDoc['name'];
     notifyListeners();

--- a/lib/models/group_models/group_song_details_model.dart
+++ b/lib/models/group_models/group_song_details_model.dart
@@ -4,18 +4,18 @@ import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 
 class GroupSongDetailsModel extends ChangeNotifier {
-  String groupID = '';
+  String groupId = '';
   Song song;
-  String songID = '';
+  String songId = '';
   String songTitle = '';
   String songMemo = '';
   int songPlayingTime;
   bool isLoading = false;
 
-  void init({String groupID, Song song}) {
-    this.groupID = groupID;
+  void init({String groupId, Song song}) {
+    this.groupId = groupId;
     this.song = song;
-    this.songID = song.id;
+    this.songId = song.id;
     this.songTitle = song.title;
     this.songMemo = song.memo;
     this.songPlayingTime = song.playingTime;
@@ -36,12 +36,12 @@ class GroupSongDetailsModel extends ChangeNotifier {
     try {
       DocumentSnapshot songDoc = await FirebaseFirestore.instance
           .collection('groups')
-          .doc(groupID)
+          .doc(groupId)
           .collection('songs')
-          .doc(songID)
+          .doc(songId)
           .get();
       song = Song.doc(songDoc);
-      songID = song.id;
+      songId = song.id;
       songTitle = song.title;
       songMemo = song.memo;
       songPlayingTime = song.playingTime;
@@ -55,9 +55,9 @@ class GroupSongDetailsModel extends ChangeNotifier {
     try {
       await FirebaseFirestore.instance
           .collection('groups')
-          .doc(groupID)
+          .doc(groupId)
           .collection('songs')
-          .doc(songID)
+          .doc(songId)
           .delete();
     } catch (e) {
       print(e);

--- a/lib/models/group_models/group_song_list_model.dart
+++ b/lib/models/group_models/group_song_list_model.dart
@@ -22,11 +22,11 @@ class GroupSongListModel extends ChangeNotifier {
   );
   MainAxisAlignment buttonAlignment = MainAxisAlignment.center;
 
-  Future getSongList(groupID) async {
+  Future getSongList({String groupId}) async {
     isLoading = true;
     var songDoc = await FirebaseFirestore.instance
         .collection('groups')
-        .doc(groupID)
+        .doc(groupId)
         .collection('songs')
         .orderBy('createdAt', descending: false)
         .get();
@@ -68,7 +68,7 @@ class GroupSongListModel extends ChangeNotifier {
     notifyListeners();
   }
 
-  void selectSong(Song song) {
+  void selectSong({Song song}) {
     song.toggleCheckBoxState();
     if (song.checkboxState == true) {
       selectedSongs.add(song.title);

--- a/lib/models/group_models/group_task_details_model.dart
+++ b/lib/models/group_models/group_task_details_model.dart
@@ -5,14 +5,14 @@ import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 
 class GroupTaskDetailsModel extends ChangeNotifier {
-  String groupID = '';
+  String groupId = '';
   Task task;
-  String taskID = '';
+  String taskId = '';
   String taskTitle = '';
   String taskMemo = '';
   bool isDecidedDueDate;
   DateTime dueDate;
-  List<dynamic> assignedMembersID = [];
+  List<dynamic> assignedMembersId = [];
   Map<String, User> groupMembers = {};
   bool isCompleted;
   bool isLoading = false;
@@ -29,18 +29,18 @@ class GroupTaskDetailsModel extends ChangeNotifier {
     notifyListeners();
   }
 
-  Future init({String groupID, Task task}) async {
+  Future init({String groupId, Task task}) async {
     startLoading();
-    this.groupID = groupID;
+    this.groupId = groupId;
     this.task = task;
-    this.taskID = task.id;
+    this.taskId = task.id;
     this.taskTitle = task.title;
     this.taskMemo = task.memo;
     this.isDecidedDueDate = task.isDecidedDueDate;
     this.dueDate = task.dueDate;
-    this.assignedMembersID = task.assignedMembersID;
+    this.assignedMembersId = task.assignedMembersId;
     this.isCompleted = task.isCompleted;
-    this.groupDocRef = firestore.collection('groups').doc(groupID);
+    this.groupDocRef = firestore.collection('groups').doc(groupId);
     try {
       QuerySnapshot groupUsers =
           await groupDocRef.collection('groupUsers').get();
@@ -55,7 +55,7 @@ class GroupTaskDetailsModel extends ChangeNotifier {
   }
 
   Future getTask() async {
-    final taskDocRef = groupDocRef.collection('tasks').doc(taskID);
+    final taskDocRef = groupDocRef.collection('tasks').doc(taskId);
     try {
       DocumentSnapshot taskDoc = await taskDocRef.get();
       this.task = Task.doc(taskDoc);
@@ -63,7 +63,7 @@ class GroupTaskDetailsModel extends ChangeNotifier {
       this.taskMemo = task.memo;
       this.isDecidedDueDate = task.isDecidedDueDate;
       this.dueDate = task.dueDate;
-      this.assignedMembersID = task.assignedMembersID;
+      this.assignedMembersId = task.assignedMembersId;
       this.isCompleted = task.isCompleted;
     } catch (e) {
       print(e);
@@ -74,7 +74,7 @@ class GroupTaskDetailsModel extends ChangeNotifier {
 
   Future deleteTask() async {
     try {
-      await groupDocRef.collection('tasks').doc(taskID).delete();
+      await groupDocRef.collection('tasks').doc(taskId).delete();
     } catch (e) {
       print(e);
       throw ('エラーが発生しました');

--- a/lib/models/group_models/group_task_list_model.dart
+++ b/lib/models/group_models/group_task_list_model.dart
@@ -23,9 +23,9 @@ class GroupTaskListModel extends ChangeNotifier {
     notifyListeners();
   }
 
-  Future init({String groupID}) async {
+  Future init({String groupId}) async {
     startLoading();
-    groupDocRef = firestore.collection('groups').doc(groupID);
+    groupDocRef = firestore.collection('groups').doc(groupId);
     try {
       QuerySnapshot groupUsers =
           await groupDocRef.collection('groupUsers').get();

--- a/lib/models/group_setting_models/group_edit_name_model.dart
+++ b/lib/models/group_setting_models/group_edit_name_model.dart
@@ -2,13 +2,13 @@ import 'package:flutter/material.dart';
 import 'package:cloud_firestore/cloud_firestore.dart';
 
 class GroupEditNameModel extends ChangeNotifier {
-  String groupID;
+  String groupId;
   String groupName = '';
   bool isLoading = false;
-  List<String> groupUsersID = [];
+  List<String> groupUsersId = [];
 
-  void init({groupID, groupName}) {
-    this.groupID = groupID;
+  void init({groupId, groupName}) {
+    this.groupId = groupId;
     this.groupName = groupName;
   }
 
@@ -29,22 +29,22 @@ class GroupEditNameModel extends ChangeNotifier {
     try {
       final groupUsers = await FirebaseFirestore.instance
           .collection('groups')
-          .doc(groupID)
+          .doc(groupId)
           .collection('groupUsers')
           .get();
-      groupUsersID = (groupUsers.docs.map((doc) => doc.id).toList());
+      groupUsersId = (groupUsers.docs.map((doc) => doc.id).toList());
       await FirebaseFirestore.instance
           .collection('groups')
-          .doc(groupID)
+          .doc(groupId)
           .update({
         'name': groupName,
       });
-      for (String userID in groupUsersID) {
+      for (String userId in groupUsersId) {
         await FirebaseFirestore.instance
             .collection('users')
-            .doc(userID)
+            .doc(userId)
             .collection('joiningGroup')
-            .doc(groupID)
+            .doc(groupId)
             .update({
           'name': groupName,
         });

--- a/lib/models/group_setting_models/group_member_model.dart
+++ b/lib/models/group_setting_models/group_member_model.dart
@@ -3,10 +3,10 @@ import 'package:firebase_auth/firebase_auth.dart' as Auth;
 import 'package:flutter/material.dart';
 
 class GroupMemberModel extends ChangeNotifier {
-  String groupID = '';
+  String groupId = '';
   String groupName = '';
-  String myID = '';
-  List<String> userIDs = [];
+  String myId = '';
+  List<String> usersId = [];
   List<String> userNames = [];
   List<String> userImageURLs = [];
   bool isLoading = false;
@@ -21,23 +21,23 @@ class GroupMemberModel extends ChangeNotifier {
     notifyListeners();
   }
 
-  Future init({groupID}) async {
+  Future init({String groupId}) async {
     startLoading();
-    this.groupID = groupID;
-    myID = Auth.FirebaseAuth.instance.currentUser.uid;
+    this.groupId = groupId;
+    myId = Auth.FirebaseAuth.instance.currentUser.uid;
     try {
       DocumentSnapshot groupDoc = await FirebaseFirestore.instance
           .collection('groups')
-          .doc(groupID)
+          .doc(groupId)
           .get();
       groupName = groupDoc['name'];
 
       QuerySnapshot groupUsers = await FirebaseFirestore.instance
           .collection('groups')
-          .doc(groupID)
+          .doc(groupId)
           .collection('groupUsers')
           .get();
-      userIDs = (groupUsers.docs.map((doc) => doc.id).toList());
+      usersId = (groupUsers.docs.map((doc) => doc.id).toList());
       userNames =
           (groupUsers.docs.map((doc) => doc['name'].toString()).toList());
       userImageURLs =
@@ -49,14 +49,14 @@ class GroupMemberModel extends ChangeNotifier {
     }
   }
 
-  Future deleteMember({String userID}) async {
+  Future deleteMember({String userId}) async {
     final userDocRef =
-        FirebaseFirestore.instance.collection('users').doc(userID);
+        FirebaseFirestore.instance.collection('users').doc(userId);
     final groupDocRef =
-        FirebaseFirestore.instance.collection('groups').doc(groupID);
+        FirebaseFirestore.instance.collection('groups').doc(groupId);
     try {
-      await userDocRef.collection('joiningGroup').doc(groupID).delete();
-      await groupDocRef.collection('groupUsers').doc(userID).delete();
+      await userDocRef.collection('joiningGroup').doc(groupId).delete();
+      await groupDocRef.collection('groupUsers').doc(userId).delete();
     } catch (e) {
       print(e);
       throw ('エラーが発生しました');

--- a/lib/models/user_models/user_add_event_model.dart
+++ b/lib/models/user_models/user_add_event_model.dart
@@ -134,7 +134,7 @@ class UserAddEventModel extends ChangeNotifier {
     notifyListeners();
   }
 
-  Future addEvent({userID}) async {
+  Future addEvent({String userId}) async {
     if (eventTitle.isEmpty) {
       throw ('タイトルを入力してください');
     }
@@ -183,10 +183,10 @@ class UserAddEventModel extends ChangeNotifier {
     try {
       await FirebaseFirestore.instance
           .collection('users')
-          .doc(userID)
+          .doc(userId)
           .collection('events')
           .add({
-        'ownerID': userID,
+        'ownerId': userId,
         'title': eventTitle,
         'place': eventPlace,
         'memo': eventMemo,

--- a/lib/models/user_models/user_add_task_model.dart
+++ b/lib/models/user_models/user_add_task_model.dart
@@ -5,12 +5,12 @@ import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:intl/intl.dart';
 
 class UserAddTaskModel extends ChangeNotifier {
-  String userID = '';
+  String userId = '';
   String taskTitle = '';
   String taskMemo = '';
   String dueDateText = '';
   bool isDecidedDueDate = true;
-  List<String> assignedUserID = [];
+  List<String> assignedUserId = [];
   bool isLoading = false;
   bool isShowDueDatePicker = false;
   Widget dueDatePickerBox = SizedBox();
@@ -28,10 +28,10 @@ class UserAddTaskModel extends ChangeNotifier {
     notifyListeners();
   }
 
-  void init({String userID}) async {
+  void init({String userId}) async {
     startLoading();
-    this.userID = userID;
-    this.assignedUserID = [userID];
+    this.userId = userId;
+    this.assignedUserId = [userId];
     this.dueDate = DateTime(now.year, now.month, now.day, 12);
     this.dueDateText = dateFormat.format(dueDate);
     try {} catch (e) {
@@ -95,15 +95,15 @@ class UserAddTaskModel extends ChangeNotifier {
     try {
       await FirebaseFirestore.instance
           .collection('users')
-          .doc(userID)
+          .doc(userId)
           .collection('tasks')
           .add({
         'title': taskTitle,
         'memo': taskMemo,
         'isDecidedDueDate': isDecidedDueDate,
         'dueDate': isDecidedDueDate ? Timestamp.fromDate(dueDate) : null,
-        'assignedMembersID': assignedUserID,
-        'ownerID': userID,
+        'assignedMembersId': assignedUserId,
+        'ownerId': userId,
         'isCompleted': false,
         'createdAt': FieldValue.serverTimestamp(),
         'updatedAt': FieldValue.serverTimestamp(),

--- a/lib/models/user_models/user_calendar_model.dart
+++ b/lib/models/user_models/user_calendar_model.dart
@@ -6,7 +6,7 @@ import 'package:nholiday_jp/nholiday_jp.dart';
 import 'package:beet/objects/content_owner.dart';
 
 class UserCalendarModel extends ChangeNotifier {
-  String userID = '';
+  String userId = '';
   DateTime now = DateTime.now();
   DateTime first;
   DateTime last;
@@ -18,14 +18,14 @@ class UserCalendarModel extends ChangeNotifier {
   final DateFormat dateFormat = DateFormat('y-MM-dd');
   final DateFormat monthFormat = DateFormat('y-MM');
 
-  void init({String userID}) {
-    this.userID = userID;
+  void init({String userId}) {
+    this.userId = userId;
     this.selectedDay = DateTime(now.year, now.month, now.day, 12);
   }
 
   Future getEvents() async {
     events = {};
-    List<String> ownerIDList = [userID];
+    List<String> ownerIdList = [userId];
     List<Event> eventList;
     List<Event> eventsOfDay;
     DateTime firstDate = DateTime(first.year, first.month, first.day, 12);
@@ -35,16 +35,16 @@ class UserCalendarModel extends ChangeNotifier {
     try {
       QuerySnapshot joiningGroupDoc = await FirebaseFirestore.instance
           .collection('users')
-          .doc(userID)
+          .doc(userId)
           .collection('joiningGroup')
           .get();
-      ownerIDList.addAll(joiningGroupDoc.docs.map((doc) => doc.id).toList());
+      ownerIdList.addAll(joiningGroupDoc.docs.map((doc) => doc.id).toList());
 
-      await fetchContentOwnerInfo(ownerIDList: ownerIDList);
+      await fetchContentOwnerInfo(ownerIdList: ownerIdList);
 
       QuerySnapshot eventDoc = await FirebaseFirestore.instance
           .collectionGroup('events')
-          .where('ownerID', whereIn: ownerIDList)
+          .where('ownerId', whereIn: ownerIdList)
           .where('monthList', arrayContains: monthForm)
           .get();
 
@@ -62,8 +62,8 @@ class UserCalendarModel extends ChangeNotifier {
     }
   }
 
-  Future fetchContentOwnerInfo({ownerIDList}) async {
-    for (String id in ownerIDList) {
+  Future fetchContentOwnerInfo({ownerIdList}) async {
+    for (String id in ownerIdList) {
       if (id.length == 28) {
         DocumentSnapshot userDoc =
             await FirebaseFirestore.instance.collection('users').doc(id).get();

--- a/lib/models/user_models/user_edit_event_model.dart
+++ b/lib/models/user_models/user_edit_event_model.dart
@@ -5,8 +5,8 @@ import 'package:flutter/material.dart';
 import 'package:intl/intl.dart';
 
 class UserEditEventModel extends ChangeNotifier {
-  String ownerID = '';
-  String eventID = '';
+  String ownerId = '';
+  String eventId = '';
   String eventTitle = '';
   String eventPlace = '';
   String eventMemo = '';
@@ -36,7 +36,7 @@ class UserEditEventModel extends ChangeNotifier {
     notifyListeners();
   }
 
-  void init({String userID, Event event}) {
+  void init({String userId, Event event}) {
     if (event.isAllDay == true) {
       this.tileDateFormat = DateFormat('y/M/d(E)', 'ja_JP');
       this.cupertinoDatePickerMode = CupertinoDatePickerMode.date;
@@ -63,17 +63,17 @@ class UserEditEventModel extends ChangeNotifier {
         );
       }
     }
-    this.ownerID = event.ownerID;
-    this.eventID = event.id;
+    this.ownerId = event.ownerId;
+    this.eventId = event.id;
     this.eventTitle = event.title;
     this.eventPlace = event.place;
     this.eventMemo = event.memo;
     this.isAllDay = event.isAllDay;
     this.startingDateTime = event.startingDateTime;
     this.endingDateTime = event.endingDateTime;
-    this.ownerDocRef = ownerID == userID
-        ? firestore.collection('users').doc(userID)
-        : firestore.collection('groups').doc(ownerID);
+    this.ownerDocRef = ownerId == userId
+        ? firestore.collection('users').doc(userId)
+        : firestore.collection('groups').doc(ownerId);
     notifyListeners();
   }
 
@@ -222,7 +222,7 @@ class UserEditEventModel extends ChangeNotifier {
     }
 
     try {
-      await this.ownerDocRef.collection('events').doc(this.eventID).update({
+      await this.ownerDocRef.collection('events').doc(this.eventId).update({
         'title': this.eventTitle,
         'place': this.eventPlace,
         'memo': this.eventMemo,

--- a/lib/models/user_models/user_edit_task_model.dart
+++ b/lib/models/user_models/user_edit_task_model.dart
@@ -7,15 +7,15 @@ import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:intl/intl.dart';
 
 class UserEditTaskModel extends ChangeNotifier {
-  String ownerID = '';
-  String taskID = '';
+  String ownerId = '';
+  String taskId = '';
   String taskTitle = '';
   String taskMemo = '';
   String dueDateText = '';
   bool isDecidedDueDate;
   bool isCompleted;
-  List<String> assignedMembersID = [];
-  List<String> usersID = [];
+  List<String> assignedMembersId = [];
+  List<String> usersId = [];
   Map<String, User> groupMembers = {};
   bool isLoading = false;
   bool isShowDueDatePicker = false;
@@ -35,28 +35,28 @@ class UserEditTaskModel extends ChangeNotifier {
     notifyListeners();
   }
 
-  void init({String userID, Task task}) async {
+  void init({String userId, Task task}) async {
     startLoading();
-    this.taskID = task.id;
-    this.ownerID = task.ownerID;
+    this.taskId = task.id;
+    this.ownerId = task.ownerId;
     this.taskTitle = task.title;
     this.taskMemo = task.memo;
     this.isDecidedDueDate = task.isDecidedDueDate;
     this.isCompleted = task.isCompleted;
     this.dueDate = task.dueDate;
     this.dueDateText = task.isDecidedDueDate ? dateFormat.format(dueDate) : '';
-    this.assignedMembersID =
-        task.assignedMembersID.map((id) => id.toString()).toList();
-    this.ownerDocRef = ownerID == userID
-        ? firestore.collection('users').doc(userID)
-        : firestore.collection('groups').doc(ownerID);
+    this.assignedMembersId =
+        task.assignedMembersId.map((id) => id.toString()).toList();
+    this.ownerDocRef = ownerId == userId
+        ? firestore.collection('users').doc(userId)
+        : firestore.collection('groups').doc(ownerId);
     try {
-      if (ownerID == userID) {
+      if (ownerId == userId) {
         final userDoc = await ownerDocRef.get();
-        groupMembers[userID] = User.doc(userDoc);
+        groupMembers[userId] = User.doc(userDoc);
       } else {
         final groupUsers = await ownerDocRef.collection('groupUsers').get();
-        this.usersID = groupUsers.docs.map((doc) => doc.id).toList();
+        this.usersId = groupUsers.docs.map((doc) => doc.id).toList();
         final users = groupUsers.docs.map((doc) => User.doc(doc)).toList();
         users.forEach((user) {
           groupMembers[user.id] = user;
@@ -69,11 +69,11 @@ class UserEditTaskModel extends ChangeNotifier {
     }
   }
 
-  void assignPerson(userID) {
-    if (assignedMembersID.contains(userID)) {
-      assignedMembersID.remove(userID);
+  void assignPerson({String userId}) {
+    if (assignedMembersId.contains(userId)) {
+      assignedMembersId.remove(userId);
     } else {
-      assignedMembersID.add(userID);
+      assignedMembersId.add(userId);
     }
     notifyListeners();
   }
@@ -130,12 +130,12 @@ class UserEditTaskModel extends ChangeNotifier {
       throw ('やることを入力してください');
     }
     try {
-      await ownerDocRef.collection('tasks').doc(taskID).update({
+      await ownerDocRef.collection('tasks').doc(taskId).update({
         'title': taskTitle,
         'memo': taskMemo,
         'isDecidedDueDate': isDecidedDueDate,
         'dueDate': isDecidedDueDate ? Timestamp.fromDate(dueDate) : null,
-        'assignedMembersID': assignedMembersID,
+        'assignedMembersId': assignedMembersId,
         'updatedAt': FieldValue.serverTimestamp(),
       });
     } catch (e) {

--- a/lib/models/user_models/user_event_details_model.dart
+++ b/lib/models/user_models/user_event_details_model.dart
@@ -5,10 +5,10 @@ import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 
 class UserEventDetailsModel extends ChangeNotifier {
-  String userID = '';
+  String userId = '';
   Event event;
-  String ownerID = '';
-  String eventID = '';
+  String ownerId = '';
+  String eventId = '';
   String eventTitle = '';
   String eventPlace = '';
   String eventMemo = '';
@@ -29,21 +29,21 @@ class UserEventDetailsModel extends ChangeNotifier {
     notifyListeners();
   }
 
-  Future init({String userID, Event event}) async {
+  Future init({String userId, Event event}) async {
     startLoading();
-    this.userID = userID;
+    this.userId = userId;
     this.event = event;
-    this.ownerID = event.ownerID;
-    this.eventID = event.id;
+    this.ownerId = event.ownerId;
+    this.eventId = event.id;
     this.eventTitle = event.title;
     this.eventPlace = event.place;
     this.eventMemo = event.memo;
     this.isAllDay = event.isAllDay;
     this.startingDateTime = event.startingDateTime;
     this.endingDateTime = event.endingDateTime;
-    final ownerDocRef = ownerID == userID
-        ? firestore.collection('users').doc(ownerID)
-        : firestore.collection('groups').doc(ownerID);
+    final ownerDocRef = ownerId == userId
+        ? firestore.collection('users').doc(ownerId)
+        : firestore.collection('groups').doc(ownerId);
     try {
       final ownerDoc = await ownerDocRef.get();
       this.owner = ContentOwner.doc(ownerDoc);
@@ -54,22 +54,22 @@ class UserEventDetailsModel extends ChangeNotifier {
   }
 
   Future getEvent() async {
-    final eventDocRef = this.ownerID == this.userID
+    final eventDocRef = this.ownerId == this.userId
         ? firestore
             .collection('users')
-            .doc(this.userID)
+            .doc(this.userId)
             .collection('events')
-            .doc(this.eventID)
+            .doc(this.eventId)
         : firestore
             .collection('groups')
-            .doc(this.ownerID)
+            .doc(this.ownerId)
             .collection('events')
-            .doc(this.eventID);
+            .doc(this.eventId);
     try {
       DocumentSnapshot eventDoc = await eventDocRef.get();
       this.event = Event.doc(eventDoc);
-      this.ownerID = event.ownerID;
-      this.eventID = event.id;
+      this.ownerId = event.ownerId;
+      this.eventId = event.id;
       this.eventTitle = event.title;
       this.eventPlace = event.place;
       this.eventMemo = event.memo;
@@ -84,11 +84,11 @@ class UserEventDetailsModel extends ChangeNotifier {
   }
 
   Future deleteEvent() async {
-    final ownerDocRef = this.ownerID == this.userID
-        ? firestore.collection('users').doc(this.userID)
-        : firestore.collection('groups').doc(this.ownerID);
+    final ownerDocRef = this.ownerId == this.userId
+        ? firestore.collection('users').doc(this.userId)
+        : firestore.collection('groups').doc(this.ownerId);
     try {
-      await ownerDocRef.collection('events').doc(this.eventID).delete();
+      await ownerDocRef.collection('events').doc(this.eventId).delete();
     } catch (e) {
       print(e);
       throw ('エラーが発生しました');

--- a/lib/models/user_models/user_main_model.dart
+++ b/lib/models/user_models/user_main_model.dart
@@ -22,13 +22,13 @@ class UserMainModel extends ChangeNotifier {
     notifyListeners();
   }
 
-  Future init({String userID}) async {
+  Future init({String userId}) async {
     taskCount = 0;
     startLoading();
     try {
       final taskQuery = await firestore
           .collectionGroup('tasks')
-          .where('assignedMembersID', arrayContains: userID)
+          .where('assignedMembersId', arrayContains: userId)
           .get();
       final tasks = taskQuery.docs.map((doc) => Task.doc(doc)).toList();
       tasks.forEach((task) {
@@ -36,29 +36,29 @@ class UserMainModel extends ChangeNotifier {
           taskCount += 1;
         }
       });
-      await getEventList(userID: userID);
+      await getEventList(userId: userId);
     } catch (e) {
       print(e);
     }
     endLoading();
   }
 
-  Future getEventList({String userID}) async {
+  Future getEventList({String userId}) async {
     final currentTimestamp = Timestamp.fromDate(currentDateTime);
-    List<String> ownerIDList = [userID];
+    List<String> ownerIdList = [userId];
     try {
       QuerySnapshot joiningGroupDoc = await FirebaseFirestore.instance
           .collection('users')
-          .doc(userID)
+          .doc(userId)
           .collection('joiningGroup')
           .get();
-      ownerIDList.addAll(joiningGroupDoc.docs.map((doc) => doc.id).toList());
+      ownerIdList.addAll(joiningGroupDoc.docs.map((doc) => doc.id).toList());
 
-      await fetchContentOwnerInfo(ownerIDList: ownerIDList);
+      await fetchContentOwnerInfo(ownerIdList: ownerIdList);
 
       QuerySnapshot eventDoc = await FirebaseFirestore.instance
           .collectionGroup('events')
-          .where('ownerID', whereIn: ownerIDList)
+          .where('ownerId', whereIn: ownerIdList)
           .where('end', isGreaterThan: currentTimestamp)
           .get();
       eventList = eventDoc.docs.map((doc) => Event.doc(doc)).toList();
@@ -71,8 +71,8 @@ class UserMainModel extends ChangeNotifier {
     notifyListeners();
   }
 
-  Future fetchContentOwnerInfo({ownerIDList}) async {
-    for (String id in ownerIDList) {
+  Future fetchContentOwnerInfo({List<String> ownerIdList}) async {
+    for (String id in ownerIdList) {
       if (id.length == 28) {
         DocumentSnapshot userDoc =
             await FirebaseFirestore.instance.collection('users').doc(id).get();

--- a/lib/models/user_models/user_model.dart
+++ b/lib/models/user_models/user_model.dart
@@ -8,12 +8,12 @@ class UserModel extends ChangeNotifier {
   BuildContext context;
   final dynamicLinks = DynamicLinksServices();
 
-  Future init({String userID, BuildContext context}) async {
+  Future init({String userId, BuildContext context}) async {
     this.context = context;
     dynamicLinks.fetchLinkData(this.context);
 
     DocumentSnapshot userDoc =
-        await FirebaseFirestore.instance.collection('users').doc(userID).get();
+        await FirebaseFirestore.instance.collection('users').doc(userId).get();
     userName = userDoc['name'];
     notifyListeners();
   }

--- a/lib/models/user_models/user_task_details_model.dart
+++ b/lib/models/user_models/user_task_details_model.dart
@@ -6,15 +6,15 @@ import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 
 class UserTaskDetailsModel extends ChangeNotifier {
-  String userID = '';
+  String userId = '';
   Task task;
-  String ownerID = '';
-  String taskID = '';
+  String ownerId = '';
+  String taskId = '';
   String taskTitle = '';
   String taskMemo = '';
   bool isDecidedDueDate;
   DateTime dueDate;
-  List<dynamic> assignedMembersID = [];
+  List<dynamic> assignedMembersId = [];
   Map<String, User> groupMembers = {};
   bool isCompleted;
   bool isLoading = false;
@@ -32,26 +32,26 @@ class UserTaskDetailsModel extends ChangeNotifier {
     notifyListeners();
   }
 
-  Future init({String userID, Task task}) async {
+  Future init({String userId, Task task}) async {
     startLoading();
-    this.userID = userID;
+    this.userId = userId;
     this.task = task;
-    this.ownerID = task.ownerID;
-    this.taskID = task.id;
+    this.ownerId = task.ownerId;
+    this.taskId = task.id;
     this.taskTitle = task.title;
     this.taskMemo = task.memo;
     this.isDecidedDueDate = task.isDecidedDueDate;
     this.dueDate = task.dueDate;
-    this.assignedMembersID = task.assignedMembersID;
+    this.assignedMembersId = task.assignedMembersId;
     this.isCompleted = task.isCompleted;
-    this.ownerDocRef = ownerID == userID
-        ? firestore.collection('users').doc(userID)
-        : firestore.collection('groups').doc(ownerID);
+    this.ownerDocRef = ownerId == userId
+        ? firestore.collection('users').doc(userId)
+        : firestore.collection('groups').doc(ownerId);
     try {
       final ownerDoc = await ownerDocRef.get();
       this.owner = ContentOwner.doc(ownerDoc);
-      if (ownerID == userID) {
-        groupMembers[ownerID] = User.doc(ownerDoc);
+      if (ownerId == userId) {
+        groupMembers[ownerId] = User.doc(ownerDoc);
       } else {
         QuerySnapshot groupUsers =
             await ownerDocRef.collection('groupUsers').get();
@@ -69,14 +69,14 @@ class UserTaskDetailsModel extends ChangeNotifier {
   Future getTask() async {
     try {
       DocumentSnapshot taskDoc =
-          await ownerDocRef.collection('tasks').doc(taskID).get();
+          await ownerDocRef.collection('tasks').doc(taskId).get();
       this.task = Task.doc(taskDoc);
-      this.ownerID = task.ownerID;
+      this.ownerId = task.ownerId;
       this.taskTitle = task.title;
       this.taskMemo = task.memo;
       this.isDecidedDueDate = task.isDecidedDueDate;
       this.dueDate = task.dueDate;
-      this.assignedMembersID = task.assignedMembersID;
+      this.assignedMembersId = task.assignedMembersId;
       this.isCompleted = task.isCompleted;
     } catch (e) {
       print(e);
@@ -87,7 +87,7 @@ class UserTaskDetailsModel extends ChangeNotifier {
 
   Future deleteTask() async {
     try {
-      await ownerDocRef.collection('tasks').doc(taskID).delete();
+      await ownerDocRef.collection('tasks').doc(taskId).delete();
     } catch (e) {
       print(e);
       throw ('エラーが発生しました');

--- a/lib/models/user_setting_models/user_edit_name_model.dart
+++ b/lib/models/user_setting_models/user_edit_name_model.dart
@@ -2,15 +2,10 @@ import 'package:flutter/material.dart';
 import 'package:cloud_firestore/cloud_firestore.dart';
 
 class UserEditNameModel extends ChangeNotifier {
-  String userID;
+  String userId;
   String userName = '';
   bool isLoading = false;
-  List<String> joiningGroupsID = [];
-
-  void init({userID, userName}) {
-    this.userID = userID;
-    this.userName = userName;
-  }
+  List<String> joiningGroupsId = [];
 
   void startLoading() {
     isLoading = true;
@@ -22,6 +17,11 @@ class UserEditNameModel extends ChangeNotifier {
     notifyListeners();
   }
 
+  void init({String userId, String userName}) {
+    this.userId = userId;
+    this.userName = userName;
+  }
+
   Future updateUserName() async {
     if (userName.isEmpty) {
       throw ('名前を入力してください');
@@ -29,19 +29,19 @@ class UserEditNameModel extends ChangeNotifier {
     try {
       final joiningGroups = await FirebaseFirestore.instance
           .collection('users')
-          .doc(userID)
+          .doc(userId)
           .collection('joiningGroup')
           .get();
-      joiningGroupsID = (joiningGroups.docs.map((doc) => doc.id).toList());
-      await FirebaseFirestore.instance.collection('users').doc(userID).update({
+      joiningGroupsId = (joiningGroups.docs.map((doc) => doc.id).toList());
+      await FirebaseFirestore.instance.collection('users').doc(userId).update({
         'name': userName,
       });
-      for (String groupID in joiningGroupsID) {
+      for (String groupId in joiningGroupsId) {
         await FirebaseFirestore.instance
             .collection('groups')
-            .doc(groupID)
+            .doc(groupId)
             .collection('groupUsers')
-            .doc(userID)
+            .doc(userId)
             .update({
           'name': userName,
         });

--- a/lib/models/user_setting_models/user_security_model.dart
+++ b/lib/models/user_setting_models/user_security_model.dart
@@ -2,14 +2,14 @@ import 'package:firebase_auth/firebase_auth.dart' as Auth;
 import 'package:flutter/material.dart';
 
 class UserSecurityModel extends ChangeNotifier {
-  String userID;
+  String userId;
   String email;
   bool isLoading = false;
 
-  void init({userID}) {
-    this.userID = userID;
+  void init({String userId}) {
+    this.userId = userId;
     final firebaseUser = Auth.FirebaseAuth.instance.currentUser;
-    email = firebaseUser.email;
+    this.email = firebaseUser.email;
     notifyListeners();
   }
 

--- a/lib/models/user_setting_models/user_update_email_model.dart
+++ b/lib/models/user_setting_models/user_update_email_model.dart
@@ -8,10 +8,6 @@ class UserUpdateEmailModel extends ChangeNotifier {
   bool isAuthRequired = false;
   final _auth = Auth.FirebaseAuth.instance;
 
-  void init({email}) {
-    this.email = email;
-  }
-
   void startLoading() {
     isLoading = true;
     notifyListeners();
@@ -20,6 +16,10 @@ class UserUpdateEmailModel extends ChangeNotifier {
   void endLoading() {
     isLoading = false;
     notifyListeners();
+  }
+
+  void init({String email}) {
+    this.email = email;
   }
 
   Future updateEmail() async {

--- a/lib/models/welcome_model.dart
+++ b/lib/models/welcome_model.dart
@@ -3,7 +3,7 @@ import 'package:firebase_auth/firebase_auth.dart' as Auth;
 import 'package:cloud_firestore/cloud_firestore.dart';
 
 class WelcomeModel extends ChangeNotifier {
-  String userID;
+  String userId;
   String name = '';
   String email = '';
   String password = '';
@@ -37,8 +37,8 @@ class WelcomeModel extends ChangeNotifier {
         password: password,
       ))
           .user;
-      userID = user.uid;
-      await FirebaseFirestore.instance.collection('users').doc(userID).set({
+      userId = user.uid;
+      await FirebaseFirestore.instance.collection('users').doc(userId).set({
         'name': name,
         'imageURL': '',
         'createdAt': FieldValue.serverTimestamp(),
@@ -62,7 +62,7 @@ class WelcomeModel extends ChangeNotifier {
         password: password,
       );
       Auth.User user = _auth.currentUser;
-      userID = user.uid;
+      userId = user.uid;
     } catch (e) {
       throw (_convertErrorMessage(e.code));
     }

--- a/lib/my_app.dart
+++ b/lib/my_app.dart
@@ -78,7 +78,7 @@ class MyApp extends StatelessWidget {
         return WelcomeScreen();
 
       case UserState.loggedIn: // 登録済み
-        return UserScreen(userID: model.userID);
+        return UserScreen(userId: model.userId);
 
       default: // 不明
         return LoginScreen();

--- a/lib/my_app_model.dart
+++ b/lib/my_app_model.dart
@@ -7,7 +7,7 @@ import 'package:firebase_auth/firebase_auth.dart' as Auth;
 import 'package:firebase_core/firebase_core.dart';
 
 class MyAppModel {
-  String userID;
+  String userId;
 
   // ignore: close_sinks
   final _userStateStreamController = StreamController<UserState>();
@@ -60,7 +60,7 @@ class MyAppModel {
       return null;
     }
     User user = User.doc(doc);
-    userID = user.id;
+    userId = user.id;
     return user;
   }
 }

--- a/lib/objects/event.dart
+++ b/lib/objects/event.dart
@@ -2,7 +2,7 @@ import 'package:cloud_firestore/cloud_firestore.dart';
 
 class Event {
   final String id;
-  final String ownerID;
+  final String ownerId;
   final String title;
   final String place;
   final String memo;
@@ -13,7 +13,7 @@ class Event {
 
   Event._(
     this.id,
-    this.ownerID,
+    this.ownerId,
     this.title,
     this.place,
     this.memo,
@@ -27,7 +27,7 @@ class Event {
     final data = doc.data();
     return Event._(
       doc.id,
-      data['ownerID'],
+      data['ownerId'],
       data['title'],
       data['place'],
       data['memo'],

--- a/lib/objects/task.dart
+++ b/lib/objects/task.dart
@@ -2,22 +2,22 @@ import 'package:cloud_firestore/cloud_firestore.dart';
 
 class Task {
   final String id;
-  final String ownerID;
+  final String ownerId;
   final String title;
   final String memo;
   final bool isDecidedDueDate;
   final DateTime dueDate;
-  final List<dynamic> assignedMembersID;
+  final List<dynamic> assignedMembersId;
   bool isCompleted;
 
   Task._(
     this.id,
-    this.ownerID,
+    this.ownerId,
     this.title,
     this.memo,
     this.isDecidedDueDate,
     this.dueDate,
-    this.assignedMembersID,
+    this.assignedMembersId,
     this.isCompleted,
   );
 
@@ -25,12 +25,12 @@ class Task {
     final data = doc.data();
     return Task._(
       doc.id,
-      data['ownerID'],
+      data['ownerId'],
       data['title'],
       data['memo'],
       data['isDecidedDueDate'],
       doc['isDecidedDueDate'] ? doc['dueDate'].toDate() : DateTime.now(),
-      doc['assignedMembersID'],
+      doc['assignedMembersId'],
       doc['isCompleted'],
     );
   }

--- a/lib/screens/add_group_screen.dart
+++ b/lib/screens/add_group_screen.dart
@@ -96,7 +96,7 @@ class AddGroupScreen extends StatelessWidget {
                                   MaterialPageRoute(
                                     builder: (BuildContext context) =>
                                         GroupScreen(
-                                      groupID: model.groupID,
+                                      groupId: model.groupId,
                                     ),
                                   ),
                                 );

--- a/lib/screens/add_group_screen.dart
+++ b/lib/screens/add_group_screen.dart
@@ -5,16 +5,12 @@ import 'package:provider/provider.dart';
 import 'package:beet/models/add_group_model.dart';
 
 class AddGroupScreen extends StatelessWidget {
-  AddGroupScreen({this.userName, this.userImageURL});
-  final String userName;
-  final String userImageURL;
   final groupNameController = TextEditingController();
 
   @override
   Widget build(BuildContext context) {
     return ChangeNotifierProvider<AddGroupModel>(
-      create: (_) =>
-          AddGroupModel()..init(userName: userName, userImageURL: userImageURL),
+      create: (_) => AddGroupModel()..init(),
       child: WillPopScope(
         onWillPop: () async {
           FocusScope.of(context).unfocus();
@@ -90,16 +86,23 @@ class AddGroupScreen extends StatelessWidget {
                               model.startLoading();
                               try {
                                 await model.addGroup();
-                                await _showTextDialog(context, '新規グループを作成しました');
-                                Navigator.pushReplacement(
-                                  context,
-                                  MaterialPageRoute(
-                                    builder: (BuildContext context) =>
-                                        GroupScreen(
-                                      groupId: model.groupId,
+                                if (model.groupId.isNotEmpty) {
+                                  await _showTextDialog(
+                                      context, '新規グループを作成しました');
+                                  Navigator.pushReplacement(
+                                    context,
+                                    MaterialPageRoute(
+                                      builder: (BuildContext context) =>
+                                          GroupScreen(
+                                        groupId: model.groupId,
+                                      ),
                                     ),
-                                  ),
-                                );
+                                  );
+                                } else {
+                                  await _showTextDialog(
+                                      context, '参加できるグループの数は8個までです');
+                                  Navigator.pop(context);
+                                }
                               } catch (e) {
                                 _showTextDialog(context, e.toString());
                               }

--- a/lib/screens/drawer_screen.dart
+++ b/lib/screens/drawer_screen.dart
@@ -90,10 +90,7 @@ class DrawerScreen extends StatelessWidget {
                         Navigator.push(
                           context,
                           MaterialPageRoute(
-                            builder: (context) => AddGroupScreen(
-                              userName: model.userName,
-                              userImageURL: model.userImageURL,
-                            ),
+                            builder: (context) => AddGroupScreen(),
                             fullscreenDialog: true,
                           ),
                         );

--- a/lib/screens/drawer_screen.dart
+++ b/lib/screens/drawer_screen.dart
@@ -39,7 +39,7 @@ class DrawerScreen extends StatelessWidget {
                         context,
                         MaterialPageRoute(
                           builder: (context) =>
-                              UserScreen(userID: model.userID),
+                              UserScreen(userId: model.userId),
                         ),
                       );
                     },
@@ -48,11 +48,11 @@ class DrawerScreen extends StatelessWidget {
                     child: Scrollbar(
                       child: ListView.builder(
                         physics: ScrollPhysics(),
-                        itemCount: model.groupName.length,
+                        itemCount: model.groupsName.length,
                         itemBuilder: (BuildContext context, int index) {
                           return ListTile(
                             title: Text(
-                              model.groupName[index],
+                              model.groupsName[index],
                               style: TextStyle(
                                 color: kPrimaryColor,
                               ),
@@ -63,7 +63,7 @@ class DrawerScreen extends StatelessWidget {
                                 context,
                                 MaterialPageRoute(
                                   builder: (context) => GroupScreen(
-                                    groupID: model.groupID[index],
+                                    groupId: model.groupsId[index],
                                   ),
                                 ),
                               );

--- a/lib/screens/group_screens/group_add_event_screen.dart
+++ b/lib/screens/group_screens/group_add_event_screen.dart
@@ -6,8 +6,8 @@ import 'package:intl/intl.dart';
 import 'package:provider/provider.dart';
 
 class GroupAddEventScreen extends StatelessWidget {
-  GroupAddEventScreen({this.groupID, this.dateTime});
-  final groupID;
+  GroupAddEventScreen({this.groupId, this.dateTime});
+  final groupId;
   final dateTime;
   final dateFormat = DateFormat('y/M/d(E)    H:mm', 'ja_jp');
   final eventTitleController = TextEditingController();
@@ -49,7 +49,7 @@ class GroupAddEventScreen extends StatelessWidget {
                         onPressed: () async {
                           model.startLoading();
                           try {
-                            await model.addEvent(groupID: groupID);
+                            await model.addEvent(groupId: groupId);
                             Navigator.pop(context);
                           } catch (e) {
                             _showTextDialog(context, e.toString());

--- a/lib/screens/group_screens/group_add_song_screen.dart
+++ b/lib/screens/group_screens/group_add_song_screen.dart
@@ -6,8 +6,8 @@ import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 
 class GroupAddSongScreen extends StatelessWidget {
-  GroupAddSongScreen({this.groupID});
-  final String groupID;
+  GroupAddSongScreen({this.groupId});
+  final String groupId;
   final songTitleController = TextEditingController();
   final songMemoController = TextEditingController();
   final scrollController = ScrollController();
@@ -38,7 +38,7 @@ class GroupAddSongScreen extends StatelessWidget {
                       onPressed: () async {
                         model.startLoading();
                         try {
-                          await model.addSong(groupID);
+                          await model.addSong(groupId: groupId);
                           Navigator.pop(context);
                         } catch (e) {
                           _showTextDialog(context, e.toString());

--- a/lib/screens/group_screens/group_add_task_screen.dart
+++ b/lib/screens/group_screens/group_add_task_screen.dart
@@ -6,8 +6,8 @@ import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 
 class GroupAddTaskScreen extends StatelessWidget {
-  GroupAddTaskScreen({this.groupID});
-  final String groupID;
+  GroupAddTaskScreen({this.groupId});
+  final String groupId;
   final taskTitleController = TextEditingController();
   final taskMemoController = TextEditingController();
   final scrollController = ScrollController();
@@ -15,7 +15,7 @@ class GroupAddTaskScreen extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return ChangeNotifierProvider<GroupAddTaskModel>(
-      create: (_) => GroupAddTaskModel()..init(groupID: groupID),
+      create: (_) => GroupAddTaskModel()..init(groupId: groupId),
       child: Consumer<GroupAddTaskModel>(builder: (context, model, child) {
         return Stack(
           children: [
@@ -104,7 +104,7 @@ class GroupAddTaskScreen extends StatelessWidget {
                                       itemCount: model.userNames.length,
                                       itemBuilder:
                                           (BuildContext context, int index) {
-                                        String userID = model.userIDs[index];
+                                        String userId = model.usersId[index];
                                         String userName =
                                             model.userNames[index];
                                         String userImageURL =
@@ -112,10 +112,10 @@ class GroupAddTaskScreen extends StatelessWidget {
                                         return AssignTaskListTile(
                                           userName: userName,
                                           userImageURL: userImageURL,
-                                          isChecked: model.assignedMembersID
-                                              .contains(userID),
+                                          isChecked: model.assignedMembersId
+                                              .contains(userId),
                                           tileTappedCallback: () {
-                                            model.assignPerson(userID);
+                                            model.assignPerson(userId);
                                           },
                                         );
                                       },

--- a/lib/screens/group_screens/group_calendar_screen.dart
+++ b/lib/screens/group_screens/group_calendar_screen.dart
@@ -2,26 +2,26 @@ import 'package:beet/screens/group_screens/group_add_event_screen.dart';
 import 'package:beet/screens/group_screens/group_event_details_screen.dart';
 import 'package:beet/widgets/basic_divider.dart';
 import 'package:beet/widgets/event_list_tile.dart';
-import 'package:beet/widgets/calendar.dart';
+import 'package:beet/widgets/calendar_widget.dart';
 import 'package:flutter/material.dart';
 import 'package:beet/models/group_models/group_calendar_model.dart';
 import 'package:beet/widgets/add_floating_action_button.dart';
 import 'package:provider/provider.dart';
 
 class GroupCalendarScreen extends StatelessWidget {
-  GroupCalendarScreen({this.groupID});
-  final String groupID;
+  GroupCalendarScreen({this.groupId});
+  final String groupId;
 
   @override
   Widget build(BuildContext context) {
     return ChangeNotifierProvider<GroupCalendarModel>(
-      create: (_) => GroupCalendarModel()..init(groupID: groupID),
+      create: (_) => GroupCalendarModel()..init(groupId: groupId),
       child: Consumer<GroupCalendarModel>(builder: (context, model, child) {
         return Stack(
           children: <Widget>[
             Column(
               children: <Widget>[
-                Calendar(model: model),
+                CalendarWidget(model: model),
                 BasicDivider(),
                 Expanded(
                   child: Scrollbar(
@@ -39,7 +39,7 @@ class GroupCalendarScreen extends StatelessWidget {
                                 context,
                                 MaterialPageRoute(
                                   builder: (context) => GroupEventDetailsScreen(
-                                    groupID: groupID,
+                                    groupId: groupId,
                                     event: event,
                                   ),
                                 ),
@@ -63,7 +63,7 @@ class GroupCalendarScreen extends StatelessWidget {
                   context,
                   MaterialPageRoute(
                     builder: (context) => GroupAddEventScreen(
-                      groupID: groupID,
+                      groupId: groupId,
                       dateTime: model.selectedDay,
                     ),
                     fullscreenDialog: true,

--- a/lib/screens/group_screens/group_edit_event_screen.dart
+++ b/lib/screens/group_screens/group_edit_event_screen.dart
@@ -7,8 +7,8 @@ import 'package:intl/intl.dart';
 import 'package:provider/provider.dart';
 
 class GroupEditEventScreen extends StatelessWidget {
-  GroupEditEventScreen({this.groupID, this.event});
-  final String groupID;
+  GroupEditEventScreen({this.groupId, this.event});
+  final String groupId;
   final Event event;
   final dateFormat = DateFormat('y/M/d(E)    H:mm', 'ja_jp');
   final eventTitleController = TextEditingController();
@@ -45,7 +45,7 @@ class GroupEditEventScreen extends StatelessWidget {
                       onPressed: () async {
                         model.startLoading();
                         try {
-                          await model.updateEvent(groupID: groupID);
+                          await model.updateEvent(groupId: groupId);
                           Navigator.pop(context);
                         } catch (e) {
                           _showTextDialog(context, e.toString());

--- a/lib/screens/group_screens/group_edit_song_screen.dart
+++ b/lib/screens/group_screens/group_edit_song_screen.dart
@@ -7,8 +7,8 @@ import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 
 class GroupEditSongScreen extends StatelessWidget {
-  GroupEditSongScreen({this.groupID, this.song});
-  final String groupID;
+  GroupEditSongScreen({this.groupId, this.song});
+  final String groupId;
   final Song song;
   final songTitleController = TextEditingController();
   final songMemoController = TextEditingController();
@@ -21,7 +21,7 @@ class GroupEditSongScreen extends StatelessWidget {
     songTitleController.text = song.title;
     songMemoController.text = song.memo;
     return ChangeNotifierProvider<GroupEditSongModel>(
-      create: (_) => GroupEditSongModel()..init(groupID: groupID, song: song),
+      create: (_) => GroupEditSongModel()..init(groupId: groupId, song: song),
       child: Consumer<GroupEditSongModel>(builder: (context, model, child) {
         return GestureDetector(
           onTap: () {

--- a/lib/screens/group_screens/group_edit_task_screen.dart
+++ b/lib/screens/group_screens/group_edit_task_screen.dart
@@ -7,8 +7,8 @@ import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 
 class GroupEditTaskScreen extends StatelessWidget {
-  GroupEditTaskScreen({this.groupID, this.task});
-  final String groupID;
+  GroupEditTaskScreen({this.groupId, this.task});
+  final String groupId;
   final Task task;
   final taskTitleController = TextEditingController();
   final taskMemoController = TextEditingController();
@@ -19,7 +19,7 @@ class GroupEditTaskScreen extends StatelessWidget {
     taskTitleController.text = task.title;
     taskMemoController.text = task.memo;
     return ChangeNotifierProvider<GroupEditTaskModel>(
-      create: (_) => GroupEditTaskModel()..init(groupID: groupID, task: task),
+      create: (_) => GroupEditTaskModel()..init(groupId: groupId, task: task),
       child: Consumer<GroupEditTaskModel>(builder: (context, model, child) {
         return Stack(
           children: [
@@ -108,7 +108,7 @@ class GroupEditTaskScreen extends StatelessWidget {
                                       itemCount: model.userNames.length,
                                       itemBuilder:
                                           (BuildContext context, int index) {
-                                        String userID = model.userIDs[index];
+                                        String userId = model.usersId[index];
                                         String userName =
                                             model.userNames[index];
                                         String userImageURL =
@@ -116,10 +116,10 @@ class GroupEditTaskScreen extends StatelessWidget {
                                         return AssignTaskListTile(
                                           userName: userName,
                                           userImageURL: userImageURL,
-                                          isChecked: model.assignedMembersID
-                                              .contains(userID),
+                                          isChecked: model.assignedMembersId
+                                              .contains(userId),
                                           tileTappedCallback: () {
-                                            model.assignPerson(userID);
+                                            model.assignPerson(userId);
                                           },
                                         );
                                       },

--- a/lib/screens/group_screens/group_event_details_screen.dart
+++ b/lib/screens/group_screens/group_event_details_screen.dart
@@ -9,8 +9,8 @@ import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 
 class GroupEventDetailsScreen extends StatelessWidget {
-  GroupEventDetailsScreen({this.groupID, this.event});
-  final String groupID;
+  GroupEventDetailsScreen({this.groupId, this.event});
+  final String groupId;
   final Event event;
 
   @override
@@ -37,7 +37,7 @@ class GroupEventDetailsScreen extends StatelessWidget {
                         context,
                         MaterialPageRoute(
                           builder: (context) => GroupEditEventScreen(
-                            groupID: groupID,
+                            groupId: groupId,
                             event: model.event,
                           ),
                           fullscreenDialog: true,
@@ -45,7 +45,7 @@ class GroupEventDetailsScreen extends StatelessWidget {
                       );
                       model.startLoading();
                       try {
-                        await model.getEvent(groupID: groupID);
+                        await model.getEvent(groupId: groupId);
                       } catch (e) {
                         _showTextDialog(context, e.toString());
                       }
@@ -120,7 +120,7 @@ class GroupEventDetailsScreen extends StatelessWidget {
                           if (isDelete == true) {
                             model.startLoading();
                             try {
-                              await model.deleteEvent(groupID: groupID);
+                              await model.deleteEvent(groupId: groupId);
                               Navigator.pop(context);
                             } catch (e) {
                               _showTextDialog(context, e.toString());

--- a/lib/screens/group_screens/group_main_screen.dart
+++ b/lib/screens/group_screens/group_main_screen.dart
@@ -8,14 +8,14 @@ import 'package:intl/intl.dart';
 import 'package:provider/provider.dart';
 
 class GroupMainScreen extends StatelessWidget {
-  GroupMainScreen({this.groupID});
-  final String groupID;
+  GroupMainScreen({this.groupId});
+  final String groupId;
   final dateFormat = DateFormat('y/M/d(E)', 'ja_JP');
 
   @override
   Widget build(BuildContext context) {
     return ChangeNotifierProvider<GroupMainModel>(
-      create: (_) => GroupMainModel()..init(groupID: groupID),
+      create: (_) => GroupMainModel()..init(groupId: groupId),
       child: Consumer<GroupMainModel>(builder: (context, model, child) {
         return Stack(
           children: [
@@ -101,14 +101,14 @@ class GroupMainScreen extends StatelessWidget {
                                 context,
                                 MaterialPageRoute(
                                   builder: (context) => GroupEventDetailsScreen(
-                                    groupID: groupID,
+                                    groupId: groupId,
                                     event: event,
                                   ),
                                 ),
                               );
                               model.startLoading();
                               try {
-                                await model.getEventList(groupID: groupID);
+                                await model.getEventList(groupId: groupId);
                               } catch (e) {
                                 _showTextDialog(context, e.toString());
                               }

--- a/lib/screens/group_screens/group_screen.dart
+++ b/lib/screens/group_screens/group_screen.dart
@@ -11,20 +11,20 @@ import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 
 class GroupScreen extends StatelessWidget {
-  GroupScreen({this.groupID});
-  final String groupID;
+  GroupScreen({this.groupId});
+  final String groupId;
 
   @override
   Widget build(BuildContext context) {
     final List<Widget> switchBody = [
-      GroupMainScreen(groupID: groupID),
-      GroupCalendarScreen(groupID: groupID),
-      GroupTaskListScreen(groupID: groupID),
-      GroupSongListScreen(groupID: groupID),
+      GroupMainScreen(groupId: groupId),
+      GroupCalendarScreen(groupId: groupId),
+      GroupTaskListScreen(groupId: groupId),
+      GroupSongListScreen(groupId: groupId),
     ];
 
     return ChangeNotifierProvider<GroupModel>(
-      create: (_) => GroupModel()..init(groupID: groupID),
+      create: (_) => GroupModel()..init(groupId: groupId),
       child: Consumer<GroupModel>(builder: (context, model, child) {
         if (model.groupName.isNotEmpty) {
           return WillPopScope(
@@ -45,11 +45,11 @@ class GroupScreen extends StatelessWidget {
                         context,
                         MaterialPageRoute(
                           builder: (context) =>
-                              GroupSettingScreen(groupID: groupID),
+                              GroupSettingScreen(groupId: groupId),
                           fullscreenDialog: true,
                         ),
                       );
-                      model.init(groupID: groupID);
+                      model.init(groupId: groupId);
                     },
                   ),
                 ],

--- a/lib/screens/group_screens/group_set_list_screen.dart
+++ b/lib/screens/group_screens/group_set_list_screen.dart
@@ -11,12 +11,12 @@ class GroupSetListScreen extends StatelessWidget {
     this.selectedSongs,
     this.songNum,
     this.totalPlayTime,
-    this.groupID,
+    this.groupId,
   });
   final List<String> selectedSongs;
   final int songNum;
   final int totalPlayTime;
-  final String groupID;
+  final String groupId;
 
   @override
   Widget build(BuildContext context) {
@@ -123,7 +123,7 @@ class GroupSetListScreen extends StatelessWidget {
                                   setList: model.setList,
                                   songNum: songNum,
                                   totalPlayTime: totalPlayTime,
-                                  groupID: groupID,
+                                  groupId: groupId,
                                 ),
                               ),
                             );

--- a/lib/screens/group_screens/group_set_list_screen_2.dart
+++ b/lib/screens/group_screens/group_set_list_screen_2.dart
@@ -12,12 +12,12 @@ class GroupSetListScreen2 extends StatelessWidget {
     this.setList,
     this.songNum,
     this.totalPlayTime,
-    this.groupID,
+    this.groupId,
   });
   final List<String> setList;
   final int songNum;
   final int totalPlayTime;
-  final String groupID;
+  final String groupId;
   final eventTitleController = TextEditingController();
   final eventPlaceController = TextEditingController();
 
@@ -142,7 +142,7 @@ class GroupSetListScreen2 extends StatelessWidget {
                                     eventDateText: model.eventDateText,
                                     songNum: songNum,
                                     totalPlayTime: totalPlayTime,
-                                    groupID: groupID,
+                                    groupId: groupId,
                                   ),
                                 ),
                               );

--- a/lib/screens/group_screens/group_set_list_screen_3.dart
+++ b/lib/screens/group_screens/group_set_list_screen_3.dart
@@ -14,7 +14,7 @@ class GroupSetListScreen3 extends StatelessWidget {
   final String eventDateText;
   final int songNum;
   final int totalPlayTime;
-  final String groupID;
+  final String groupId;
 
   GroupSetListScreen3({
     this.setList,
@@ -23,7 +23,7 @@ class GroupSetListScreen3 extends StatelessWidget {
     this.eventDateText,
     this.songNum,
     this.totalPlayTime,
-    this.groupID,
+    this.groupId,
   });
 
   @override
@@ -146,7 +146,7 @@ class GroupSetListScreen3 extends StatelessWidget {
                               context,
                               MaterialPageRoute(
                                 builder: (BuildContext context) =>
-                                    GroupScreen(groupID: groupID),
+                                    GroupScreen(groupId: groupId),
                               ),
                             );
                           },

--- a/lib/screens/group_screens/group_song_details_screen.dart
+++ b/lib/screens/group_screens/group_song_details_screen.dart
@@ -8,15 +8,15 @@ import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 
 class GroupSongDetailsScreen extends StatelessWidget {
-  GroupSongDetailsScreen({this.groupID, this.song});
-  final String groupID;
+  GroupSongDetailsScreen({this.groupId, this.song});
+  final String groupId;
   final Song song;
 
   @override
   Widget build(BuildContext context) {
     return ChangeNotifierProvider<GroupSongDetailsModel>(
       create: (_) =>
-          GroupSongDetailsModel()..init(groupID: groupID, song: song),
+          GroupSongDetailsModel()..init(groupId: groupId, song: song),
       child: Consumer<GroupSongDetailsModel>(builder: (context, model, child) {
         return Stack(
           children: [
@@ -37,7 +37,7 @@ class GroupSongDetailsScreen extends StatelessWidget {
                         context,
                         MaterialPageRoute(
                           builder: (context) => GroupEditSongScreen(
-                            groupID: groupID,
+                            groupId: groupId,
                             song: model.song,
                           ),
                           fullscreenDialog: true,

--- a/lib/screens/group_screens/group_song_list_screen.dart
+++ b/lib/screens/group_screens/group_song_list_screen.dart
@@ -10,13 +10,13 @@ import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 
 class GroupSongListScreen extends StatelessWidget {
-  GroupSongListScreen({this.groupID});
-  final String groupID;
+  GroupSongListScreen({this.groupId});
+  final String groupId;
 
   @override
   Widget build(BuildContext context) {
     return ChangeNotifierProvider<GroupSongListModel>(
-      create: (_) => GroupSongListModel()..getSongList(groupID),
+      create: (_) => GroupSongListModel()..getSongList(groupId: groupId),
       child: Consumer<GroupSongListModel>(builder: (context, model, child) {
         if (model.songList.isNotEmpty) {
           return Stack(
@@ -53,23 +53,23 @@ class GroupSongListScreen extends StatelessWidget {
                               song: song,
                               isVisible: model.isSetListMode,
                               checkboxCallback: (value) {
-                                model.selectSong(song);
+                                model.selectSong(song: song);
                               },
                               tileTappedCallback: () async {
                                 if (model.isSetListMode == true) {
-                                  model.selectSong(song);
+                                  model.selectSong(song: song);
                                 } else {
                                   await Navigator.push(
                                     context,
                                     MaterialPageRoute(
                                       builder: (context) =>
                                           GroupSongDetailsScreen(
-                                        groupID: groupID,
+                                        groupId: groupId,
                                         song: song,
                                       ),
                                     ),
                                   );
-                                  model.getSongList(groupID);
+                                  model.getSongList(groupId: groupId);
                                 }
                               },
                             );
@@ -112,7 +112,7 @@ class GroupSongListScreen extends StatelessWidget {
                                             selectedSongs: model.selectedSongs,
                                             songNum: model.songNum,
                                             totalPlayTime: model.totalPlayTime,
-                                            groupID: groupID,
+                                            groupId: groupId,
                                           ),
                                         ),
                                       );
@@ -143,11 +143,11 @@ class GroupSongListScreen extends StatelessWidget {
                       context,
                       MaterialPageRoute(
                         builder: (context) =>
-                            GroupAddSongScreen(groupID: groupID),
+                            GroupAddSongScreen(groupId: groupId),
                         fullscreenDialog: true,
                       ),
                     );
-                    model.getSongList(groupID);
+                    model.getSongList(groupId: groupId);
                   },
                 ),
               ),
@@ -169,11 +169,11 @@ class GroupSongListScreen extends StatelessWidget {
                     context,
                     MaterialPageRoute(
                       builder: (context) =>
-                          GroupAddSongScreen(groupID: groupID),
+                          GroupAddSongScreen(groupId: groupId),
                       fullscreenDialog: true,
                     ),
                   );
-                  model.getSongList(groupID);
+                  model.getSongList(groupId: groupId);
                 },
               ),
             ],

--- a/lib/screens/group_screens/group_task_details_screen.dart
+++ b/lib/screens/group_screens/group_task_details_screen.dart
@@ -9,8 +9,8 @@ import 'package:intl/intl.dart';
 import 'package:provider/provider.dart';
 
 class GroupTaskDetailsScreen extends StatelessWidget {
-  GroupTaskDetailsScreen({this.groupID, this.task});
-  final String groupID;
+  GroupTaskDetailsScreen({this.groupId, this.task});
+  final String groupId;
   final Task task;
   final dueDateFormat = DateFormat('y/M/d(E)', 'ja_JP');
 
@@ -18,7 +18,7 @@ class GroupTaskDetailsScreen extends StatelessWidget {
   Widget build(BuildContext context) {
     return ChangeNotifierProvider<GroupTaskDetailsModel>(
       create: (_) =>
-          GroupTaskDetailsModel()..init(groupID: groupID, task: task),
+          GroupTaskDetailsModel()..init(groupId: groupId, task: task),
       child: Consumer<GroupTaskDetailsModel>(builder: (context, model, child) {
         return Stack(
           children: [
@@ -39,7 +39,7 @@ class GroupTaskDetailsScreen extends StatelessWidget {
                         context,
                         MaterialPageRoute(
                           builder: (context) => GroupEditTaskScreen(
-                            groupID: groupID,
+                            groupId: groupId,
                             task: model.task,
                           ),
                           fullscreenDialog: true,
@@ -84,16 +84,16 @@ class GroupTaskDetailsScreen extends StatelessWidget {
                                       scrollDirection: Axis.horizontal,
                                       physics: ScrollPhysics(),
                                       itemExtent: 60.0,
-                                      itemCount: model.assignedMembersID.length,
+                                      itemCount: model.assignedMembersId.length,
                                       itemBuilder:
                                           (BuildContext context, int index) {
                                         String imageURL = model
                                             .groupMembers[
-                                                model.assignedMembersID[index]]
+                                                model.assignedMembersId[index]]
                                             .imageURL;
                                         String name = model
                                             .groupMembers[
-                                                model.assignedMembersID[index]]
+                                                model.assignedMembersId[index]]
                                             .name;
                                         return Padding(
                                           padding: EdgeInsets.symmetric(

--- a/lib/screens/group_screens/group_task_list_screen.dart
+++ b/lib/screens/group_screens/group_task_list_screen.dart
@@ -9,13 +9,13 @@ import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 
 class GroupTaskListScreen extends StatelessWidget {
-  GroupTaskListScreen({this.groupID});
-  final String groupID;
+  GroupTaskListScreen({this.groupId});
+  final String groupId;
 
   @override
   Widget build(BuildContext context) {
     return ChangeNotifierProvider<GroupTaskListModel>(
-      create: (_) => GroupTaskListModel()..init(groupID: groupID),
+      create: (_) => GroupTaskListModel()..init(groupId: groupId),
       child: Consumer<GroupTaskListModel>(builder: (context, model, child) {
         return Stack(
           children: [
@@ -94,7 +94,7 @@ class GroupTaskListScreen extends StatelessWidget {
                                             MaterialPageRoute(
                                               builder: (context) =>
                                                   GroupTaskDetailsScreen(
-                                                groupID: groupID,
+                                                groupId: groupId,
                                                 task: task,
                                               ),
                                             ),
@@ -157,7 +157,7 @@ class GroupTaskListScreen extends StatelessWidget {
                                             MaterialPageRoute(
                                               builder: (context) =>
                                                   GroupTaskDetailsScreen(
-                                                groupID: groupID,
+                                                groupId: groupId,
                                                 task: task,
                                               ),
                                             ),
@@ -224,7 +224,7 @@ class GroupTaskListScreen extends StatelessWidget {
                 await Navigator.push(
                   context,
                   MaterialPageRoute(
-                    builder: (context) => GroupAddTaskScreen(groupID: groupID),
+                    builder: (context) => GroupAddTaskScreen(groupId: groupId),
                     fullscreenDialog: true,
                   ),
                 );

--- a/lib/screens/group_setting_screens/group_edit_name_screen.dart
+++ b/lib/screens/group_setting_screens/group_edit_name_screen.dart
@@ -3,8 +3,8 @@ import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 
 class GroupEditNameScreen extends StatelessWidget {
-  GroupEditNameScreen({this.groupID, this.groupName});
-  final String groupID;
+  GroupEditNameScreen({this.groupId, this.groupName});
+  final String groupId;
   final String groupName;
   final groupNameController = TextEditingController();
 
@@ -13,7 +13,7 @@ class GroupEditNameScreen extends StatelessWidget {
     groupNameController.text = groupName;
     return ChangeNotifierProvider<GroupEditNameModel>(
       create: (_) =>
-          GroupEditNameModel()..init(groupID: groupID, groupName: groupName),
+          GroupEditNameModel()..init(groupId: groupId, groupName: groupName),
       child: Consumer<GroupEditNameModel>(builder: (context, model, child) {
         return Stack(
           children: [

--- a/lib/screens/group_setting_screens/group_member_screen.dart
+++ b/lib/screens/group_setting_screens/group_member_screen.dart
@@ -7,14 +7,14 @@ import 'package:flutter/services.dart';
 import 'package:provider/provider.dart';
 
 class GroupMemberScreen extends StatelessWidget {
-  GroupMemberScreen({this.groupID});
-  final groupID;
+  GroupMemberScreen({this.groupId});
+  final groupId;
   final dynamicLinks = DynamicLinksServices();
 
   @override
   Widget build(BuildContext context) {
     return ChangeNotifierProvider<GroupMemberModel>(
-      create: (_) => GroupMemberModel()..init(groupID: groupID),
+      create: (_) => GroupMemberModel()..init(groupId: groupId),
       child: Consumer<GroupMemberModel>(builder: (context, model, child) {
         return Stack(
           children: [
@@ -31,7 +31,7 @@ class GroupMemberScreen extends StatelessWidget {
                         physics: AlwaysScrollableScrollPhysics(),
                         itemCount: model.userNames.length,
                         itemBuilder: (BuildContext context, int index) {
-                          String userID = model.userIDs[index];
+                          String userId = model.usersId[index];
                           String userName = model.userNames[index];
                           String userImageURL = model.userImageURLs[index];
                           return ListTile(
@@ -46,7 +46,7 @@ class GroupMemberScreen extends StatelessWidget {
                               overflow: TextOverflow.ellipsis,
                             ),
                             onTap: () async {
-                              bool isMe = userID == model.myID;
+                              bool isMe = userId == model.myId;
                               bool isDelete = await _showMemberBottomSheet(
                                 context,
                                 isMe,
@@ -55,16 +55,16 @@ class GroupMemberScreen extends StatelessWidget {
                               if (isDelete == true) {
                                 model.startLoading();
                                 try {
-                                  await model.deleteMember(userID: userID);
+                                  await model.deleteMember(userId: userId);
                                   isMe
                                       ? Navigator.pushReplacement(
                                           context,
                                           MaterialPageRoute(
                                             builder: (BuildContext context) =>
-                                                UserScreen(userID: userID),
+                                                UserScreen(userId: userId),
                                           ),
                                         )
-                                      : model.init(groupID: groupID);
+                                      : model.init(groupId: groupId);
                                 } catch (e) {
                                   _showTextDialog(context, e.toString());
                                 }
@@ -89,7 +89,7 @@ class GroupMemberScreen extends StatelessWidget {
                       onPressed: () async {
                         model.startLoading();
                         Uri link = await dynamicLinks.createDynamicLink(
-                          groupID: groupID,
+                          groupId: groupId,
                           groupName: model.groupName,
                         );
                         model.endLoading();

--- a/lib/screens/group_setting_screens/group_profile_screen.dart
+++ b/lib/screens/group_setting_screens/group_profile_screen.dart
@@ -6,13 +6,13 @@ import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 
 class GroupProfileScreen extends StatelessWidget {
-  GroupProfileScreen({this.groupID});
-  final String groupID;
+  GroupProfileScreen({this.groupId});
+  final String groupId;
 
   @override
   Widget build(BuildContext context) {
     return ChangeNotifierProvider<GroupProfileModel>(
-      create: (_) => GroupProfileModel()..init(groupID: groupID),
+      create: (_) => GroupProfileModel()..init(groupId: groupId),
       child: Consumer<GroupProfileModel>(builder: (context, model, child) {
         return Stack(
           children: [
@@ -134,12 +134,12 @@ class GroupProfileScreen extends StatelessWidget {
                         context,
                         MaterialPageRoute(
                           builder: (context) => GroupEditNameScreen(
-                            groupID: groupID,
+                            groupId: groupId,
                             groupName: model.groupName,
                           ),
                         ),
                       );
-                      model.init(groupID: groupID);
+                      model.init(groupId: groupId);
                     },
                   ),
                   Expanded(

--- a/lib/screens/group_setting_screens/group_setting_screen.dart
+++ b/lib/screens/group_setting_screens/group_setting_screen.dart
@@ -9,8 +9,8 @@ import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 
 class GroupSettingScreen extends StatelessWidget {
-  GroupSettingScreen({this.groupID});
-  final String groupID;
+  GroupSettingScreen({this.groupId});
+  final String groupId;
 
   @override
   Widget build(BuildContext context) {
@@ -50,7 +50,7 @@ class GroupSettingScreen extends StatelessWidget {
                     context,
                     MaterialPageRoute(
                       builder: (context) =>
-                          GroupProfileScreen(groupID: groupID),
+                          GroupProfileScreen(groupId: groupId),
                     ),
                   );
                 },
@@ -65,7 +65,7 @@ class GroupSettingScreen extends StatelessWidget {
                   await Navigator.push(
                     context,
                     MaterialPageRoute(
-                      builder: (context) => GroupMemberScreen(groupID: groupID),
+                      builder: (context) => GroupMemberScreen(groupId: groupId),
                     ),
                   );
                 },

--- a/lib/screens/login_screen.dart
+++ b/lib/screens/login_screen.dart
@@ -101,7 +101,7 @@ class LoginScreen extends StatelessWidget {
                                   context,
                                   MaterialPageRoute(
                                     builder: (BuildContext context) =>
-                                        UserScreen(userID: model.userID),
+                                        UserScreen(userId: model.userId),
                                   ),
                                 );
                               } catch (e) {

--- a/lib/screens/register_screen.dart
+++ b/lib/screens/register_screen.dart
@@ -116,7 +116,7 @@ class RegisterScreen extends StatelessWidget {
                                   context,
                                   MaterialPageRoute(
                                     builder: (BuildContext context) =>
-                                        UserScreen(userID: model.userID),
+                                        UserScreen(userId: model.userId),
                                   ),
                                 );
                               } catch (e) {

--- a/lib/screens/user_screens/user_add_event_screen.dart
+++ b/lib/screens/user_screens/user_add_event_screen.dart
@@ -6,8 +6,8 @@ import 'package:intl/intl.dart';
 import 'package:provider/provider.dart';
 
 class UserAddEventScreen extends StatelessWidget {
-  UserAddEventScreen({this.userID, this.dateTime});
-  final userID;
+  UserAddEventScreen({this.userId, this.dateTime});
+  final userId;
   final dateTime;
   final dateFormat = DateFormat('y/M/d(E)    H:mm', 'ja_jp');
   final eventTitleController = TextEditingController();
@@ -49,7 +49,7 @@ class UserAddEventScreen extends StatelessWidget {
                         onPressed: () async {
                           model.startLoading();
                           try {
-                            await model.addEvent(userID: userID);
+                            await model.addEvent(userId: userId);
                             Navigator.pop(context);
                           } catch (e) {
                             _showTextDialog(context, e.toString());

--- a/lib/screens/user_screens/user_add_task_screen.dart
+++ b/lib/screens/user_screens/user_add_task_screen.dart
@@ -5,8 +5,8 @@ import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 
 class UserAddTaskScreen extends StatelessWidget {
-  UserAddTaskScreen({this.userID});
-  final String userID;
+  UserAddTaskScreen({this.userId});
+  final String userId;
   final taskTitleController = TextEditingController();
   final taskMemoController = TextEditingController();
   final scrollController = ScrollController();
@@ -14,7 +14,7 @@ class UserAddTaskScreen extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return ChangeNotifierProvider<UserAddTaskModel>(
-      create: (_) => UserAddTaskModel()..init(userID: userID),
+      create: (_) => UserAddTaskModel()..init(userId: userId),
       child: Consumer<UserAddTaskModel>(builder: (context, model, child) {
         return Stack(
           children: [

--- a/lib/screens/user_screens/user_calendar_screen.dart
+++ b/lib/screens/user_screens/user_calendar_screen.dart
@@ -1,7 +1,7 @@
 import 'package:beet/models/user_models/user_calendar_model.dart';
 import 'package:beet/screens/user_screens/user_add_event_screen.dart';
 import 'package:beet/screens/user_screens/user_event_details_screen.dart';
-import 'package:beet/widgets/calendar.dart';
+import 'package:beet/widgets/calendar_widget.dart';
 import 'package:beet/widgets/event_list_tile.dart';
 import 'package:beet/widgets/thin_divider.dart';
 import 'package:flutter/material.dart';
@@ -9,19 +9,19 @@ import 'package:beet/widgets/add_floating_action_button.dart';
 import 'package:provider/provider.dart';
 
 class UserCalendarScreen extends StatelessWidget {
-  UserCalendarScreen({this.userID});
-  final String userID;
+  UserCalendarScreen({this.userId});
+  final String userId;
 
   @override
   Widget build(BuildContext context) {
     return ChangeNotifierProvider<UserCalendarModel>(
-      create: (_) => UserCalendarModel()..init(userID: userID),
+      create: (_) => UserCalendarModel()..init(userId: userId),
       child: Consumer<UserCalendarModel>(builder: (context, model, child) {
         return Stack(
           children: <Widget>[
             Column(
               children: <Widget>[
-                Calendar(model: model),
+                CalendarWidget(model: model),
                 ThinDivider(),
                 Expanded(
                   child: Scrollbar(
@@ -35,14 +35,14 @@ class UserCalendarScreen extends StatelessWidget {
                           return EventListTile(
                             event: event,
                             imageURL:
-                                model.eventPlanner[event.ownerID].imageURL,
-                            name: model.eventPlanner[event.ownerID].name,
+                                model.eventPlanner[event.ownerId].imageURL,
+                            name: model.eventPlanner[event.ownerId].name,
                             onTap: () async {
                               await Navigator.push(
                                 context,
                                 MaterialPageRoute(
                                   builder: (context) => UserEventDetailsScreen(
-                                    userID: userID,
+                                    userId: userId,
                                     event: event,
                                   ),
                                 ),
@@ -66,7 +66,7 @@ class UserCalendarScreen extends StatelessWidget {
                   context,
                   MaterialPageRoute(
                     builder: (context) => UserAddEventScreen(
-                      userID: userID,
+                      userId: userId,
                       dateTime: model.selectedDay,
                     ),
                     fullscreenDialog: true,

--- a/lib/screens/user_screens/user_edit_event_screen.dart
+++ b/lib/screens/user_screens/user_edit_event_screen.dart
@@ -7,8 +7,8 @@ import 'package:intl/intl.dart';
 import 'package:provider/provider.dart';
 
 class UserEditEventScreen extends StatelessWidget {
-  UserEditEventScreen({this.userID, this.event});
-  final String userID;
+  UserEditEventScreen({this.userId, this.event});
+  final String userId;
   final Event event;
   final dateFormat = DateFormat('y/M/d(E)    H:mm', 'ja_jp');
   final eventTitleController = TextEditingController();
@@ -22,7 +22,7 @@ class UserEditEventScreen extends StatelessWidget {
     eventPlaceController.text = event.place;
     eventMemoController.text = event.memo;
     return ChangeNotifierProvider<UserEditEventModel>(
-      create: (_) => UserEditEventModel()..init(userID: userID, event: event),
+      create: (_) => UserEditEventModel()..init(userId: userId, event: event),
       child: Consumer<UserEditEventModel>(builder: (context, model, child) {
         return GestureDetector(
           onTap: () {

--- a/lib/screens/user_screens/user_edit_task_screen.dart
+++ b/lib/screens/user_screens/user_edit_task_screen.dart
@@ -7,8 +7,8 @@ import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 
 class UserEditTaskScreen extends StatelessWidget {
-  UserEditTaskScreen({this.userID, this.task});
-  final String userID;
+  UserEditTaskScreen({this.userId, this.task});
+  final String userId;
   final Task task;
   final taskTitleController = TextEditingController();
   final taskMemoController = TextEditingController();
@@ -19,7 +19,7 @@ class UserEditTaskScreen extends StatelessWidget {
     taskTitleController.text = task.title;
     taskMemoController.text = task.memo;
     return ChangeNotifierProvider<UserEditTaskModel>(
-      create: (_) => UserEditTaskModel()..init(userID: userID, task: task),
+      create: (_) => UserEditTaskModel()..init(userId: userId, task: task),
       child: Consumer<UserEditTaskModel>(builder: (context, model, child) {
         return Stack(
           children: [
@@ -90,7 +90,7 @@ class UserEditTaskScreen extends StatelessWidget {
                             model.dueDatePickerBox,
                             BasicDivider(),
                             Visibility(
-                              visible: model.ownerID != userID,
+                              visible: model.ownerId != userId,
                               child: Column(
                                 crossAxisAlignment: CrossAxisAlignment.start,
                                 children: [
@@ -116,21 +116,22 @@ class UserEditTaskScreen extends StatelessWidget {
                                                 model.groupMembers.length,
                                             itemBuilder: (BuildContext context,
                                                 int index) {
-                                              String userID =
-                                                  model.usersID[index];
+                                              String userId =
+                                                  model.usersId[index];
                                               String userName = model
-                                                  .groupMembers[userID].name;
+                                                  .groupMembers[userId].name;
                                               String userImageURL = model
-                                                  .groupMembers[userID]
+                                                  .groupMembers[userId]
                                                   .imageURL;
                                               return AssignTaskListTile(
                                                 userName: userName,
                                                 userImageURL: userImageURL,
                                                 isChecked: model
-                                                    .assignedMembersID
-                                                    .contains(userID),
+                                                    .assignedMembersId
+                                                    .contains(userId),
                                                 tileTappedCallback: () {
-                                                  model.assignPerson(userID);
+                                                  model.assignPerson(
+                                                      userId: userId);
                                                 },
                                               );
                                             },

--- a/lib/screens/user_screens/user_event_details_screen.dart
+++ b/lib/screens/user_screens/user_event_details_screen.dart
@@ -9,15 +9,15 @@ import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 
 class UserEventDetailsScreen extends StatelessWidget {
-  UserEventDetailsScreen({this.userID, this.event});
-  final String userID;
+  UserEventDetailsScreen({this.userId, this.event});
+  final String userId;
   final Event event;
 
   @override
   Widget build(BuildContext context) {
     return ChangeNotifierProvider<UserEventDetailsModel>(
       create: (_) =>
-          UserEventDetailsModel()..init(userID: userID, event: event),
+          UserEventDetailsModel()..init(userId: userId, event: event),
       child: Consumer<UserEventDetailsModel>(builder: (context, model, child) {
         return Stack(
           children: [
@@ -38,7 +38,7 @@ class UserEventDetailsScreen extends StatelessWidget {
                         context,
                         MaterialPageRoute(
                           builder: (context) => UserEditEventScreen(
-                            userID: userID,
+                            userId: userId,
                             event: model.event,
                           ),
                           fullscreenDialog: true,

--- a/lib/screens/user_screens/user_main_screen.dart
+++ b/lib/screens/user_screens/user_main_screen.dart
@@ -8,14 +8,14 @@ import 'package:intl/intl.dart';
 import 'package:provider/provider.dart';
 
 class UserMainScreen extends StatelessWidget {
-  UserMainScreen({this.userID});
-  final String userID;
+  UserMainScreen({this.userId});
+  final String userId;
   final dateFormat = DateFormat('y/M/d(E)', 'ja_JP');
 
   @override
   Widget build(BuildContext context) {
     return ChangeNotifierProvider<UserMainModel>(
-      create: (_) => UserMainModel()..init(userID: userID),
+      create: (_) => UserMainModel()..init(userId: userId),
       child: Consumer<UserMainModel>(builder: (context, model, child) {
         return Stack(
           children: [
@@ -97,21 +97,21 @@ class UserMainScreen extends StatelessWidget {
                           return EventListTile(
                             event: event,
                             imageURL:
-                                model.eventPlanner[event.ownerID].imageURL,
-                            name: model.eventPlanner[event.ownerID].name,
+                                model.eventPlanner[event.ownerId].imageURL,
+                            name: model.eventPlanner[event.ownerId].name,
                             onTap: () async {
                               await Navigator.push(
                                 context,
                                 MaterialPageRoute(
                                   builder: (context) => UserEventDetailsScreen(
-                                    userID: userID,
+                                    userId: userId,
                                     event: event,
                                   ),
                                 ),
                               );
                               model.startLoading();
                               try {
-                                await model.getEventList(userID: userID);
+                                await model.getEventList(userId: userId);
                               } catch (e) {
                                 _showTextDialog(context, e.toString());
                               }

--- a/lib/screens/user_screens/user_screen.dart
+++ b/lib/screens/user_screens/user_screen.dart
@@ -10,18 +10,18 @@ import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 
 class UserScreen extends StatelessWidget {
-  UserScreen({this.userID});
-  final String userID;
+  UserScreen({this.userId});
+  final String userId;
 
   @override
   Widget build(BuildContext context) {
     final List<Widget> switchBody = [
-      UserMainScreen(userID: userID),
-      UserCalendarScreen(userID: userID),
-      UserTaskListScreen(userID: userID),
+      UserMainScreen(userId: userId),
+      UserCalendarScreen(userId: userId),
+      UserTaskListScreen(userId: userId),
     ];
     return ChangeNotifierProvider<UserModel>(
-      create: (_) => UserModel()..init(userID: userID, context: context),
+      create: (_) => UserModel()..init(userId: userId, context: context),
       child: Consumer<UserModel>(builder: (context, model, child) {
         if (model.userName.isNotEmpty) {
           return WillPopScope(
@@ -44,12 +44,12 @@ class UserScreen extends StatelessWidget {
                         context,
                         MaterialPageRoute(
                           builder: (context) => UserSettingScreen(
-                            userID: userID,
+                            userId: userId,
                           ),
                           fullscreenDialog: true,
                         ),
                       );
-                      model.init(userID: userID);
+                      model.init(userId: userId);
                     },
                   ),
                 ],

--- a/lib/screens/user_screens/user_task_details_screen.dart
+++ b/lib/screens/user_screens/user_task_details_screen.dart
@@ -9,15 +9,15 @@ import 'package:intl/intl.dart';
 import 'package:provider/provider.dart';
 
 class UserTaskDetailsScreen extends StatelessWidget {
-  UserTaskDetailsScreen({this.userID, this.task});
-  final String userID;
+  UserTaskDetailsScreen({this.userId, this.task});
+  final String userId;
   final Task task;
   final dueDateFormat = DateFormat('y/M/d(E)', 'ja_JP');
 
   @override
   Widget build(BuildContext context) {
     return ChangeNotifierProvider<UserTaskDetailsModel>(
-      create: (_) => UserTaskDetailsModel()..init(userID: userID, task: task),
+      create: (_) => UserTaskDetailsModel()..init(userId: userId, task: task),
       child: Consumer<UserTaskDetailsModel>(builder: (context, model, child) {
         return Stack(
           children: [
@@ -38,7 +38,7 @@ class UserTaskDetailsScreen extends StatelessWidget {
                         context,
                         MaterialPageRoute(
                           builder: (context) => UserEditTaskScreen(
-                            userID: userID,
+                            userId: userId,
                             task: model.task,
                           ),
                           fullscreenDialog: true,
@@ -106,16 +106,16 @@ class UserTaskDetailsScreen extends StatelessWidget {
                                       scrollDirection: Axis.horizontal,
                                       physics: ScrollPhysics(),
                                       itemExtent: 60.0,
-                                      itemCount: model.assignedMembersID.length,
+                                      itemCount: model.assignedMembersId.length,
                                       itemBuilder:
                                           (BuildContext context, int index) {
                                         String imageURL = model
                                             .groupMembers[
-                                                model.assignedMembersID[index]]
+                                                model.assignedMembersId[index]]
                                             .imageURL;
                                         String name = model
                                             .groupMembers[
-                                                model.assignedMembersID[index]]
+                                                model.assignedMembersId[index]]
                                             .name;
                                         return Padding(
                                           padding: EdgeInsets.symmetric(

--- a/lib/screens/user_screens/user_task_list_screen.dart
+++ b/lib/screens/user_screens/user_task_list_screen.dart
@@ -9,13 +9,13 @@ import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 
 class UserTaskListScreen extends StatelessWidget {
-  UserTaskListScreen({this.userID});
-  final String userID;
+  UserTaskListScreen({this.userId});
+  final String userId;
 
   @override
   Widget build(BuildContext context) {
     return ChangeNotifierProvider<UserTaskListModel>(
-      create: (_) => UserTaskListModel()..init(userID: userID),
+      create: (_) => UserTaskListModel()..init(userId: userId),
       child: Consumer<UserTaskListModel>(builder: (context, model, child) {
         return Stack(
           children: [
@@ -94,7 +94,7 @@ class UserTaskListScreen extends StatelessWidget {
                                             MaterialPageRoute(
                                               builder: (context) =>
                                                   UserTaskDetailsScreen(
-                                                userID: userID,
+                                                userId: userId,
                                                 task: task,
                                               ),
                                             ),
@@ -102,7 +102,7 @@ class UserTaskListScreen extends StatelessWidget {
                                           model.startLoading();
                                           try {
                                             await model.getTaskList(
-                                                userID: userID);
+                                                userId: userId);
                                           } catch (e) {
                                             _showTextDialog(
                                                 context, e.toString());
@@ -158,7 +158,7 @@ class UserTaskListScreen extends StatelessWidget {
                                             MaterialPageRoute(
                                               builder: (context) =>
                                                   UserTaskDetailsScreen(
-                                                userID: userID,
+                                                userId: userId,
                                                 task: task,
                                               ),
                                             ),
@@ -166,7 +166,7 @@ class UserTaskListScreen extends StatelessWidget {
                                           model.startLoading();
                                           try {
                                             await model.getTaskList(
-                                                userID: userID);
+                                                userId: userId);
                                           } catch (e) {
                                             _showTextDialog(
                                                 context, e.toString());
@@ -205,7 +205,7 @@ class UserTaskListScreen extends StatelessWidget {
                             model.startLoading();
                             try {
                               await model.updateCheckState();
-                              await model.getTaskList(userID: userID);
+                              await model.getTaskList(userId: userId);
                             } catch (e) {
                               _showTextDialog(context, e.toString());
                             }
@@ -231,12 +231,12 @@ class UserTaskListScreen extends StatelessWidget {
                   context,
                   MaterialPageRoute(
                     builder: (context) => UserAddTaskScreen(
-                      userID: userID,
+                      userId: userId,
                     ),
                     fullscreenDialog: true,
                   ),
                 );
-                model.getTaskList(userID: userID);
+                model.getTaskList(userId: userId);
               },
             ),
             model.isLoading

--- a/lib/screens/user_setting_screens/user_edit_name_screen.dart
+++ b/lib/screens/user_setting_screens/user_edit_name_screen.dart
@@ -3,8 +3,8 @@ import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 
 class UserEditNameScreen extends StatelessWidget {
-  UserEditNameScreen({this.userID, this.userName});
-  final String userID;
+  UserEditNameScreen({this.userId, this.userName});
+  final String userId;
   final String userName;
   final userNameController = TextEditingController();
 
@@ -13,7 +13,7 @@ class UserEditNameScreen extends StatelessWidget {
     userNameController.text = userName;
     return ChangeNotifierProvider<UserEditNameModel>(
       create: (_) =>
-          UserEditNameModel()..init(userID: userID, userName: userName),
+          UserEditNameModel()..init(userId: userId, userName: userName),
       child: Consumer<UserEditNameModel>(builder: (context, model, child) {
         return Stack(
           children: [

--- a/lib/screens/user_setting_screens/user_profile_screen.dart
+++ b/lib/screens/user_setting_screens/user_profile_screen.dart
@@ -7,13 +7,13 @@ import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 
 class UserProfileScreen extends StatelessWidget {
-  UserProfileScreen({this.userID});
-  final String userID;
+  UserProfileScreen({this.userId});
+  final String userId;
 
   @override
   Widget build(BuildContext context) {
     return ChangeNotifierProvider<UserProfileModel>(
-      create: (_) => UserProfileModel()..init(userID: userID),
+      create: (_) => UserProfileModel()..init(userId: userId),
       child: Consumer<UserProfileModel>(builder: (context, model, child) {
         return Stack(
           children: [
@@ -149,12 +149,12 @@ class UserProfileScreen extends StatelessWidget {
                                   context,
                                   MaterialPageRoute(
                                     builder: (context) => UserEditNameScreen(
-                                      userID: userID,
+                                      userId: userId,
                                       userName: model.userName,
                                     ),
                                   ),
                                 );
-                                model.init(userID: userID);
+                                model.init(userId: userId);
                               },
                             ),
                             Expanded(

--- a/lib/screens/user_setting_screens/user_security_screen.dart
+++ b/lib/screens/user_setting_screens/user_security_screen.dart
@@ -8,12 +8,12 @@ import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 
 class UserSecurityScreen extends StatelessWidget {
-  UserSecurityScreen({this.userID});
-  final String userID;
+  UserSecurityScreen({this.userId});
+  final String userId;
   @override
   Widget build(BuildContext context) {
     return ChangeNotifierProvider<UserSecurityModel>(
-      create: (_) => UserSecurityModel()..init(userID: userID),
+      create: (_) => UserSecurityModel()..init(userId: userId),
       child: Consumer<UserSecurityModel>(builder: (context, model, child) {
         return Stack(
           children: [
@@ -40,7 +40,7 @@ class UserSecurityScreen extends StatelessWidget {
                               ),
                             ),
                           );
-                          model.init(userID: userID);
+                          model.init(userId: userId);
                         },
                       ),
                     ),

--- a/lib/screens/user_setting_screens/user_setting_screen.dart
+++ b/lib/screens/user_setting_screens/user_setting_screen.dart
@@ -9,8 +9,8 @@ import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 
 class UserSettingScreen extends StatelessWidget {
-  UserSettingScreen({this.userID});
-  final String userID;
+  UserSettingScreen({this.userId});
+  final String userId;
 
   @override
   Widget build(BuildContext context) {
@@ -49,7 +49,7 @@ class UserSettingScreen extends StatelessWidget {
                   await Navigator.push(
                     context,
                     MaterialPageRoute(
-                      builder: (context) => UserProfileScreen(userID: userID),
+                      builder: (context) => UserProfileScreen(userId: userId),
                     ),
                   );
                 },
@@ -64,7 +64,7 @@ class UserSettingScreen extends StatelessWidget {
                   await Navigator.push(
                     context,
                     MaterialPageRoute(
-                      builder: (context) => UserSecurityScreen(userID: userID),
+                      builder: (context) => UserSecurityScreen(userId: userId),
                     ),
                   );
                 },

--- a/lib/services/dynamic_links_services.dart
+++ b/lib/services/dynamic_links_services.dart
@@ -9,10 +9,10 @@ class DynamicLinksServices {
   BuildContext context;
   Auth.User user = Auth.FirebaseAuth.instance.currentUser;
 
-  Future<Uri> createDynamicLink({String groupID, String groupName}) async {
+  Future<Uri> createDynamicLink({String groupId, String groupName}) async {
     final DynamicLinkParameters parameters = DynamicLinkParameters(
       uriPrefix: 'https://beetana.page.link',
-      link: Uri.parse('https://beetana.page.link/?id=$groupID&name=$groupName'),
+      link: Uri.parse('https://beetana.page.link/?id=$groupId&name=$groupName'),
       androidParameters: AndroidParameters(
         packageName: 'com.beetana.beet',
         minimumVersion: 1,
@@ -53,15 +53,15 @@ class DynamicLinksServices {
   }
 
   void handleLinkData(PendingDynamicLinkData data) {
-    String invitedGroupID = '';
+    String invitedGroupId = '';
     String invitedGroupName = '';
 
     final Uri deepLink = data?.link;
     if (deepLink != null) {
       final queryParams = deepLink.queryParameters;
-      invitedGroupID = queryParams['id'];
+      invitedGroupId = queryParams['id'];
       invitedGroupName = queryParams['name'];
-      invitedDialog(context, invitedGroupID, invitedGroupName);
+      invitedDialog(context, invitedGroupId, invitedGroupName);
 
       print(queryParams);
       print('招待されたグループのIDは${queryParams['id']}');
@@ -69,7 +69,7 @@ class DynamicLinksServices {
     }
   }
 
-  Future invitedDialog(context, groupID, groupName) async {
+  Future invitedDialog(context, groupId, groupName) async {
     await showDialog(
       context: context,
       builder: (BuildContext context) {
@@ -80,7 +80,7 @@ class DynamicLinksServices {
               child: Text('参加'),
               onPressed: () async {
                 showIndicator(context);
-                final isAlreadyJoin = await joinGroup(groupID);
+                final isAlreadyJoin = await joinGroup(groupId: groupId);
                 if (isAlreadyJoin == true) {
                   Navigator.pop(context);
                   Navigator.pop(context);
@@ -91,7 +91,7 @@ class DynamicLinksServices {
                     context,
                     MaterialPageRoute(
                       builder: (BuildContext context) => GroupScreen(
-                        groupID: groupID,
+                        groupId: groupId,
                       ),
                     ),
                   );
@@ -148,21 +148,21 @@ class DynamicLinksServices {
     );
   }
 
-  Future<bool> joinGroup(groupID) async {
-    String userID = user.uid;
+  Future<bool> joinGroup({String groupId}) async {
+    String userId = user.uid;
     String userName = '';
     String userImageURL = '';
     String groupName = '';
     String groupImageURL = '';
     bool isAlreadyJoin = false;
     final userDocRef =
-        FirebaseFirestore.instance.collection('users').doc(userID);
+        FirebaseFirestore.instance.collection('users').doc(userId);
     final groupDocRef =
-        FirebaseFirestore.instance.collection('groups').doc(groupID);
+        FirebaseFirestore.instance.collection('groups').doc(groupId);
 
     try {
       final joiningGroupDoc =
-          await userDocRef.collection('joiningGroup').doc(groupID).get();
+          await userDocRef.collection('joiningGroup').doc(groupId).get();
       print(!joiningGroupDoc.exists);
 
       if (!joiningGroupDoc.exists) {
@@ -170,7 +170,7 @@ class DynamicLinksServices {
         userName = userDoc['name'];
         userImageURL = userDoc['imageURL'];
 
-        await groupDocRef.collection('groupUsers').doc(userID).set({
+        await groupDocRef.collection('groupUsers').doc(userId).set({
           'name': userName,
           'imageURL': userImageURL,
           'joinedAt': FieldValue.serverTimestamp(),
@@ -180,7 +180,7 @@ class DynamicLinksServices {
         groupName = groupDoc['name'];
         groupImageURL = groupDoc['imageURL'];
 
-        await userDocRef.collection('joiningGroup').doc(groupID).set({
+        await userDocRef.collection('joiningGroup').doc(groupId).set({
           'name': groupName,
           'imageURL': groupImageURL,
           'joinedAt': FieldValue.serverTimestamp(),

--- a/lib/widgets/calendar_widget.dart
+++ b/lib/widgets/calendar_widget.dart
@@ -2,16 +2,16 @@ import 'package:beet/utilities/constants.dart';
 import 'package:flutter/material.dart';
 import 'package:table_calendar/table_calendar.dart';
 
-class Calendar extends StatefulWidget {
+class CalendarWidget extends StatefulWidget {
   final model;
 
-  Calendar({Key key, this.model}) : super(key: key);
+  CalendarWidget({Key key, this.model}) : super(key: key);
 
   @override
-  _CalendarState createState() => _CalendarState();
+  _CalendarWidgetState createState() => _CalendarWidgetState();
 }
 
-class _CalendarState extends State<Calendar> {
+class _CalendarWidgetState extends State<CalendarWidget> {
   CalendarController _calendarController;
 
   @override

--- a/lib/widgets/task_list_tile.dart
+++ b/lib/widgets/task_list_tile.dart
@@ -52,21 +52,21 @@ class TaskListTile extends StatelessWidget {
                       child: ListView.builder(
                         scrollDirection: Axis.horizontal,
                         physics: NeverScrollableScrollPhysics(),
-                        itemCount: task.assignedMembersID.length,
+                        itemCount: task.assignedMembersId.length,
                         itemBuilder: (context, index) {
                           return Container(
                             width: 24.0,
                             height: 24.0,
                             child: CircleAvatar(
                               backgroundImage: users[
-                                          task.assignedMembersID[index]] ==
+                                          task.assignedMembersId[index]] ==
                                       null
                                   ? AssetImage('images/test_user_image.png')
-                                  : users[task.assignedMembersID[index]]
+                                  : users[task.assignedMembersId[index]]
                                           .imageURL
                                           .isNotEmpty
                                       ? NetworkImage(
-                                          users[task.assignedMembersID[index]]
+                                          users[task.assignedMembersId[index]]
                                               .imageURL,
                                         )
                                       : AssetImage(


### PR DESCRIPTION
## 関連するissue
#9 
## 目的
firestoreのwhereIn句では10件までしかクエリできないので、参加できるグループの数を制限したかった。
## 変更点
一つのアカウントで参加できるグループの数を8個までに制限した。
新しくグループを作成する時とグループに招待された時に、すでに8個のグループに参加していた場合はその旨を伝えるメッセージと共にエラーを返す仕様にした。
